### PR TITLE
Refactor/request completion

### DIFF
--- a/ffi/rodbus-ffi/src/lib.rs
+++ b/ffi/rodbus-ffi/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::missing_safety_doc)]
+#![allow(clippy::derive_partial_eq_without_eq)]
 
 mod client;
 mod database;

--- a/ffi/rodbus-ffi/src/lib.rs
+++ b/ffi/rodbus-ffi/src/lib.rs
@@ -1,5 +1,4 @@
-#![allow(clippy::missing_safety_doc)]
-#![allow(clippy::derive_partial_eq_without_eq)]
+#![allow(clippy::all)]
 
 mod client;
 mod database;

--- a/rodbus/src/client/message.rs
+++ b/rodbus/src/client/message.rs
@@ -4,7 +4,7 @@ use crate::decode::AppDecodeLevel;
 use crate::error::AduParseError;
 use crate::error::*;
 use crate::exception::ExceptionCode;
-use crate::{tokio, DecodeLevel};
+use crate::DecodeLevel;
 
 use crate::client::requests::read_bits::ReadBits;
 use crate::client::requests::read_registers::ReadRegisters;
@@ -53,21 +53,23 @@ impl Request {
         }
     }
 
-    pub(crate) fn handle_response(self, payload: &[u8], decode: AppDecodeLevel) {
+    pub(crate) fn handle_response(
+        &mut self,
+        payload: &[u8],
+        decode: AppDecodeLevel,
+    ) -> Result<(), RequestError> {
         let expected_function = self.details.function();
         let mut cursor = ReadCursor::new(payload);
         let function = match cursor.read_u8() {
             Ok(x) => x,
             Err(err) => {
                 tracing::warn!("unable to read function code");
-                return self.details.fail(err.into());
+                return Err(err.into());
             }
         };
 
         if function != expected_function.get_value() {
-            return self
-                .details
-                .fail(Self::get_error_for(function, expected_function, cursor));
+            return Err(Self::get_error_for(function, expected_function, cursor));
         }
 
         // If we made it this far, then everything's alright
@@ -127,7 +129,7 @@ impl RequestDetails {
         }
     }
 
-    pub(crate) fn fail(self, err: RequestError) {
+    pub(crate) fn fail(&mut self, err: RequestError) {
         match self {
             RequestDetails::ReadCoils(x) => x.failure(err),
             RequestDetails::ReadDiscreteInputs(x) => x.failure(err),
@@ -140,7 +142,11 @@ impl RequestDetails {
         }
     }
 
-    fn handle_response(self, cursor: ReadCursor, decode: AppDecodeLevel) {
+    fn handle_response(
+        &mut self,
+        cursor: ReadCursor,
+        decode: AppDecodeLevel,
+    ) -> Result<(), RequestError> {
         let function = self.function();
         match self {
             RequestDetails::ReadCoils(x) => x.handle_response(cursor, function, decode),
@@ -239,28 +245,54 @@ impl std::fmt::Display for RequestDetailsDisplay<'_> {
     }
 }
 
-pub(crate) enum Promise<T> {
-    Channel(tokio::sync::oneshot::Sender<Result<T, RequestError>>),
-    Callback(Box<dyn FnOnce(Result<T, RequestError>) + Send + Sync + 'static>),
+pub(crate) struct Promise<T>
+where
+    T: Send + 'static,
+{
+    callback: Option<Box<dyn FnOnce(Result<T, RequestError>) + Send + Sync + 'static>>,
 }
 
-impl<T> Promise<T> {
-    pub(crate) fn failure(self, err: RequestError) {
+impl<T> Promise<T>
+where
+    T: Send + 'static,
+{
+    pub(crate) fn new<F>(callback: F) -> Self
+    where
+        F: FnOnce(Result<T, RequestError>) + Send + Sync + 'static,
+    {
+        Self {
+            callback: Some(Box::new(callback)),
+        }
+    }
+
+    pub(crate) fn channel(
+        tx: crate::tokio::sync::oneshot::Sender<Result<T, RequestError>>,
+    ) -> Self {
+        Self::new(|x: Result<T, RequestError>| {
+            let _ = tx.send(x);
+        })
+    }
+
+    pub(crate) fn failure(&mut self, err: RequestError) {
         self.complete(Err(err))
     }
 
-    pub(crate) fn complete(self, x: Result<T, RequestError>) {
-        match self {
-            Promise::Channel(sender) => {
-                sender.send(x).ok();
-            }
-            Promise::Callback(func) => {
-                func(x);
-            }
+    pub(crate) fn success(&mut self, value: T) {
+        self.complete(Ok(value))
+    }
+
+    fn complete(&mut self, result: Result<T, RequestError>) {
+        if let Some(callback) = self.callback.take() {
+            callback(result)
         }
     }
 }
 
-trait Callback<U> {
-    fn complete(self, result: Result<U, RequestError>);
+impl<T> Drop for Promise<T>
+where
+    T: Send + 'static,
+{
+    fn drop(&mut self) {
+        self.failure(RequestError::Shutdown);
+    }
 }

--- a/rodbus/src/client/requests/read_registers.rs
+++ b/rodbus/src/client/requests/read_registers.rs
@@ -20,6 +20,12 @@ pub(crate) struct Promise {
     callback: Option<Box<dyn RegistersCallback>>,
 }
 
+impl Drop for Promise {
+    fn drop(&mut self) {
+        self.failure(RequestError::Shutdown);
+    }
+}
+
 impl Promise {
     pub(crate) fn new<T>(callback: T) -> Self
     where

--- a/rodbus/src/client/requests/write_single.rs
+++ b/rodbus/src/client/requests/write_single.rs
@@ -15,7 +15,7 @@ pub(crate) trait SingleWriteOperation: Sized + PartialEq {
 
 pub(crate) struct SingleWrite<T>
 where
-    T: SingleWriteOperation + Display,
+    T: SingleWriteOperation + Display + Send + 'static,
 {
     pub(crate) request: T,
     promise: Promise<T>,
@@ -23,7 +23,7 @@ where
 
 impl<T> SingleWrite<T>
 where
-    T: SingleWriteOperation + Display,
+    T: SingleWriteOperation + Display + Send + 'static,
 {
     pub(crate) fn new(request: T, promise: Promise<T>) -> Self {
         Self { request, promise }
@@ -33,33 +33,26 @@ where
         self.request.serialize(cursor)
     }
 
-    pub(crate) fn failure(self, err: RequestError) {
+    pub(crate) fn failure(&mut self, err: RequestError) {
         self.promise.failure(err)
     }
 
     pub(crate) fn handle_response(
-        self,
+        &mut self,
         cursor: ReadCursor,
         function: FunctionCode,
         decode: AppDecodeLevel,
-    ) {
-        let result = self.parse_all(cursor);
+    ) -> Result<(), RequestError> {
+        let response = self.parse_all(cursor)?;
 
-        match &result {
-            Ok(response) => {
-                if decode.data_headers() {
-                    tracing::info!("PDU RX - {} {}", function, response);
-                } else if decode.header() {
-                    tracing::info!("PDU RX - {}", function);
-                }
-            }
-            Err(err) => {
-                // TODO: check if this is how we want to log it
-                tracing::warn!("{}", err);
-            }
+        if decode.data_headers() {
+            tracing::info!("PDU RX - {} {}", function, response);
+        } else if decode.header() {
+            tracing::info!("PDU RX - {}", function);
         }
 
-        self.promise.complete(result)
+        self.promise.success(response);
+        Ok(())
     }
 
     fn parse_all(&self, mut cursor: ReadCursor) -> Result<T, RequestError> {

--- a/rodbus/src/common/serialize.rs
+++ b/rodbus/src/common/serialize.rs
@@ -211,7 +211,7 @@ where
                 Err(_) => return Ok(()),
             };
 
-            write!(f, "{}", BitIteratorDisplay::new(level, &iterator))?;
+            write!(f, "{}", BitIteratorDisplay::new(level, iterator))?;
         }
 
         Ok(())
@@ -256,7 +256,7 @@ where
                 Err(_) => return Ok(()),
             };
 
-            write!(f, "{}", RegisterIteratorDisplay::new(level, &iterator))?;
+            write!(f, "{}", RegisterIteratorDisplay::new(level, iterator))?;
         }
 
         Ok(())

--- a/rodbus/src/decode.rs
+++ b/rodbus/src/decode.rs
@@ -1,5 +1,5 @@
 /// Controls the decoding of transmitted and received data at the application, frame, and physical layer
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct DecodeLevel {
     /// Controls decoding of the application layer (PDU)
     pub app: AppDecodeLevel,
@@ -12,7 +12,7 @@ pub struct DecodeLevel {
 /// Controls how transmitted and received message at the application layer are decoded at the INFO log level
 ///
 /// Application-layer messages are referred to as Protocol Data Units (PDUs) in the specification.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum AppDecodeLevel {
     /// Decode nothing
     Nothing,
@@ -30,7 +30,7 @@ pub enum AppDecodeLevel {
 /// called "ADUs" in the Modbus specification.
 ///
 /// On TCP, this is the MBAP decoding. On serial, this controls the serial line PDU.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum FrameDecodeLevel {
     /// Decode nothing
     Nothing,
@@ -41,7 +41,7 @@ pub enum FrameDecodeLevel {
 }
 
 /// Controls how data transmitted at the physical layer (TCP, serial, etc) is logged
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum PhysDecodeLevel {
     /// Log nothing
     Nothing,

--- a/rodbus/src/error.rs
+++ b/rodbus/src/error.rs
@@ -13,7 +13,7 @@ impl std::fmt::Display for Shutdown {
 }
 
 /// Top level error type for the client API
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RequestError {
     /// An I/O error occurred
     Io(::std::io::ErrorKind),

--- a/rodbus/src/error.rs
+++ b/rodbus/src/error.rs
@@ -273,7 +273,7 @@ impl std::fmt::Display for AduParseError {
 }
 
 /// errors that result because of bad request parameter
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum InvalidRequest {
     /// Request contained an invalid range
     BadRange(InvalidRange),

--- a/rodbus/src/error.rs
+++ b/rodbus/src/error.rs
@@ -122,7 +122,7 @@ impl From<InvalidRange> for RequestError {
 }
 
 /// errors that can be produced when validating start/count
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum InvalidRange {
     /// count of zero not allowed
     CountOfZero,
@@ -133,7 +133,7 @@ pub enum InvalidRange {
 }
 
 /// errors that indicate faulty logic in the library itself if they occur
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum InternalError {
     /// Insufficient space for write operation
     InsufficientWriteSpace(usize, usize), // written vs remaining space

--- a/rodbus/src/serial/mod.rs
+++ b/rodbus/src/serial/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod client;
 pub(crate) mod frame;
 
 /// serial port settings
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug)]
 pub struct SerialSettings {
     /// baud rate of the port
     pub baud_rate: u32,

--- a/rodbus/src/server/handler.rs
+++ b/rodbus/src/server/handler.rs
@@ -156,7 +156,7 @@ where
 }
 
 /// Authorization result
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthorizationResult {
     /// Client is authorized to perform the operation
     Authorized,

--- a/rodbus/src/server/request.rs
+++ b/rodbus/src/server/request.rs
@@ -242,14 +242,14 @@ impl std::fmt::Display for RequestDisplay<'_, '_> {
                     write!(
                         f,
                         " {}",
-                        BitIteratorDisplay::new(self.level, &items.iterator)
+                        BitIteratorDisplay::new(self.level, items.iterator)
                     )?;
                 }
                 Request::WriteMultipleRegisters(items) => {
                     write!(
                         f,
                         " {}",
-                        RegisterIteratorDisplay::new(self.level, &items.iterator)
+                        RegisterIteratorDisplay::new(self.level, items.iterator)
                     )?;
                 }
             }

--- a/rodbus/src/tcp/tls/client.rs
+++ b/rodbus/src/tcp/tls/client.rs
@@ -51,7 +51,7 @@ pub(crate) fn create_tls_channel(
         )
         .run()
         .instrument(tracing::info_span!("Modbus-Client-TCP", endpoint = ?host))
-        .await
+        .await;
     };
     (Channel { tx }, task)
 }

--- a/rodbus/src/tcp/tls/mod.rs
+++ b/rodbus/src/tcp/tls/mod.rs
@@ -13,7 +13,7 @@ use tokio_rustls::{rustls, webpki};
 ///
 /// This validation always occurs **after** the handshake signature has been
 /// verified.
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CertificateMode {
     /// Validates the peer certificate against one or more configured trust anchors
     ///
@@ -66,7 +66,7 @@ impl std::fmt::Display for TlsError {
 impl std::error::Error for TlsError {}
 
 /// Minimum TLS version to allow
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MinTlsVersion {
     /// TLS 1.2
     V1_2,

--- a/rodbus/src/types.rs
+++ b/rodbus/src/types.rs
@@ -68,8 +68,8 @@ pub struct BitIterator<'a> {
     pos: u16,
 }
 
-pub(crate) struct BitIteratorDisplay<'a, 'b> {
-    iterator: &'a BitIterator<'b>,
+pub(crate) struct BitIteratorDisplay<'a> {
+    iterator: BitIterator<'a>,
     level: AppDecodeLevel,
 }
 
@@ -81,8 +81,8 @@ pub struct RegisterIterator<'a> {
     pos: u16,
 }
 
-pub(crate) struct RegisterIteratorDisplay<'a, 'b> {
-    iterator: &'a RegisterIterator<'b>,
+pub(crate) struct RegisterIteratorDisplay<'a> {
+    iterator: RegisterIterator<'a>,
     level: AppDecodeLevel,
 }
 
@@ -107,19 +107,18 @@ impl<'a> BitIterator<'a> {
     }
 }
 
-impl<'a, 'b> BitIteratorDisplay<'a, 'b> {
-    pub(crate) fn new(level: AppDecodeLevel, iterator: &'a BitIterator<'b>) -> Self {
+impl<'a> BitIteratorDisplay<'a> {
+    pub(crate) fn new(level: AppDecodeLevel, iterator: BitIterator<'a>) -> Self {
         Self { iterator, level }
     }
 }
 
-impl std::fmt::Display for BitIteratorDisplay<'_, '_> {
+impl std::fmt::Display for BitIteratorDisplay<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.iterator.range)?;
 
         if self.level.data_values() {
-            // This clone is lightweigth
-            for x in *self.iterator {
+            for x in self.iterator {
                 write!(f, "\n{}", x)?;
             }
         }
@@ -143,19 +142,18 @@ impl<'a> RegisterIterator<'a> {
     }
 }
 
-impl<'a, 'b> RegisterIteratorDisplay<'a, 'b> {
-    pub(crate) fn new(level: AppDecodeLevel, iterator: &'a RegisterIterator<'b>) -> Self {
+impl<'a> RegisterIteratorDisplay<'a> {
+    pub(crate) fn new(level: AppDecodeLevel, iterator: RegisterIterator<'a>) -> Self {
         Self { iterator, level }
     }
 }
 
-impl std::fmt::Display for RegisterIteratorDisplay<'_, '_> {
+impl std::fmt::Display for RegisterIteratorDisplay<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.iterator.range)?;
 
         if self.level.data_values() {
-            // This clone is lightweigth
-            for x in *self.iterator {
+            for x in self.iterator {
                 write!(f, "\n{}", x)?;
             }
         }

--- a/rodbus/src/types.rs
+++ b/rodbus/src/types.rs
@@ -15,7 +15,7 @@ pub struct UnitId {
 
 /// Start and count tuple used when making various requests
 /// Cannot be constructed with invalid start/count
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AddressRange {
     /// starting address of the range
     pub start: u16,

--- a/rodbus/src/types.rs
+++ b/rodbus/src/types.rs
@@ -52,7 +52,7 @@ impl ReadRegistersRange {
 }
 
 /// Value and its address
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Indexed<T> {
     /// address of the value
     pub index: u16,


### PR DESCRIPTION
It was previously possible for the request callbacks not to be called under certain conditions, including if an error occurred while writing the request to the physical layer.

This PR refactors how callbacks are completed to **ensure** callbacks fire:

1) Error callbacks are always completed in one location
2) Even if the Task itself is dropped due to Runtime shutdown or Task panic, the callback will now occur in a Drop implementation.