### PR TITLE
Bug/#74

### DIFF
--- a/rodbus/src/client/mod.rs
+++ b/rodbus/src/client/mod.rs
@@ -73,13 +73,11 @@ impl HostAddr {
 }
 
 /// Spawns a channel task onto the runtime that maintains a TCP connection and processes
-/// requests from an mpsc request queue. The task completes when the returned channel handle
-/// and all derived session handles are dropped.
+/// requests. The task completes when the returned channel handle is dropped.
 ///
 /// The channel uses the provided [`ReconnectStrategy`] to pause between failed connection attempts
 ///
-/// * `host` - Address of the remote server. Can be a IP address or name on which to perform DNS resolution.
-/// * `port` - Port of the remote host
+/// * `host` - Address/port of the remote server. Can be a IP address or name on which to perform DNS resolution.
 /// * `max_queued_requests` - The maximum size of the request queue
 /// * `retry` - A boxed trait object that controls when the connection is retried on failure
 /// * `decode` - Decode log level
@@ -92,28 +90,8 @@ pub fn spawn_tcp_client_task(
     crate::tcp::client::spawn_tcp_channel(host, max_queued_requests, retry, decode)
 }
 
-/// Creates a channel task, but does not spawn it. Most users will prefer
-/// [`spawn_tcp_client_task`], unless they are using the library from outside the Tokio runtime
-/// and need to spawn it using a Runtime handle instead of the `tokio::spawn` function.
-///
-/// The channel uses the provided [`ReconnectStrategy`] to pause between failed connection attempts
-///
-/// * `host` - Address of the remote server. Can be a IP address or name on which to perform DNS resolution.
-/// * `port` - Port of the remote host
-/// * `max_queued_requests` - The maximum size of the request queue
-/// * `retry` - A boxed trait object that controls when the connection is retried on failure
-/// * `decode` - Decode log level
-pub fn create_tcp_handle_and_task(
-    host: HostAddr,
-    max_queued_requests: usize,
-    retry: Box<dyn ReconnectStrategy + Send>,
-    decode: DecodeLevel,
-) -> (Channel, impl std::future::Future<Output = ()>) {
-    crate::tcp::client::create_tcp_channel(host, max_queued_requests, retry, decode)
-}
-
 /// Spawns a channel task onto the runtime that opens a serial port and processes
-/// requests from an mpsc request queue. The task completes when the returned channel handle
+/// requests. The task completes when the returned channel handle
 /// is dropped.
 ///
 /// * `path` - Path to the serial device. Generally `/dev/tty0` on Linux and `COM1` on Windows.
@@ -137,39 +115,13 @@ pub fn spawn_rtu_client_task(
     )
 }
 
-/// Creates a RTU channel task, but does not spawn it. Most users will prefer
-/// [`spawn_rtu_client_task`], unless they are using the library from outside the Tokio runtime
-/// and need to spawn it using a Runtime handle instead of the `tokio::spawn` function.
-///
-/// * `path` - Path to the serial device. Generally `/dev/tty0` on Linux and `COM1` on Windows.
-/// * `serial_settings` = Serial port settings
-/// * `max_queued_requests` - The maximum size of the request queue
-/// * `retry` - Delay between attempts to open the serial port
-/// * `decode` - Decode log level
-pub fn create_rtu_handle_and_task(
-    path: &str,
-    serial_settings: SerialSettings,
-    max_queued_requests: usize,
-    retry_delay: Duration,
-    decode: DecodeLevel,
-) -> (Channel, impl std::future::Future<Output = ()>) {
-    Channel::create_rtu_handle_and_task(
-        path,
-        serial_settings,
-        max_queued_requests,
-        retry_delay,
-        decode,
-    )
-}
-
 /// Spawns a channel task onto the runtime that maintains a TLS connection and processes
-/// requests from an mpsc request queue. The task completes when the returned channel handle
-/// and all derived session handles are dropped.
+/// requests. The task completes when the returned channel handle
+/// is dropped.
 ///
 /// The channel uses the provided [`ReconnectStrategy`] to pause between failed connection attempts
 ///
-/// * `host` - Address of the remote server. Can be a IP address or name on which to perform DNS resolution.
-/// * `port` - Port of the remote host
+/// * `host` - Address/port of the remote server. Can be a IP address or name on which to perform DNS resolution.
 /// * `max_queued_requests` - The maximum size of the request queue
 /// * `retry` - A boxed trait object that controls when the connection is retried on failure
 /// * `tls_config` - TLS configuration
@@ -183,27 +135,4 @@ pub fn spawn_tls_client_task(
     decode: DecodeLevel,
 ) -> Channel {
     spawn_tls_channel(host, max_queued_requests, retry, tls_config, decode)
-}
-
-/// Creates a channel task, but does not spawn it. Most users will prefer
-/// [`spawn_tcp_client_task`], unless they are using the library from outside the Tokio runtime
-/// and need to spawn it using a Runtime handle instead of the `tokio::spawn` function.
-///
-/// The channel uses the provided [`ReconnectStrategy`] to pause between failed connection attempts
-///
-/// * `host` - Address of the remote server. Can be a IP address or name on which to perform DNS resolution.
-/// * `port` - Port of the remote host
-/// * `max_queued_requests` - The maximum size of the request queue
-/// * `retry` - A boxed trait object that controls when the connection is retried on failure
-/// * `tls_config` - TLS configuration
-/// * `decode` - Decode log level
-#[cfg(feature = "tls")]
-pub fn create_tls_handle_and_task(
-    host: HostAddr,
-    max_queued_requests: usize,
-    retry: Box<dyn ReconnectStrategy + Send>,
-    tls_config: TlsClientConfig,
-    decode: DecodeLevel,
-) -> (Channel, impl std::future::Future<Output = ()>) {
-    create_tls_channel(host, max_queued_requests, retry, tls_config, decode)
 }

--- a/rodbus/src/server/mod.rs
+++ b/rodbus/src/server/mod.rs
@@ -1,6 +1,5 @@
 use std::net::SocketAddr;
 
-use tokio_serial::SerialStream;
 use tracing::Instrument;
 
 use crate::common::phys::PhysLayer;
@@ -52,8 +51,8 @@ impl ServerHandle {
 }
 
 /// Spawns a TCP server task onto the runtime. This method can only
-/// be called from within the runtime context. Use [`create_tcp_server_task`]
-/// and then spawn it manually if using outside the Tokio runtime.
+/// be called from within the runtime context. Use `Runtime::enter()`
+/// to create a context on the current thread if necessary.
 ///
 /// Each incoming connection will spawn a new task to handle it.
 ///
@@ -70,70 +69,28 @@ pub async fn spawn_tcp_server_task<T: RequestHandler>(
     let listener = tokio::net::TcpListener::bind(addr).await?;
 
     let (tx, rx) = tokio::sync::mpsc::channel(SERVER_SETTING_CHANNEL_CAPACITY);
-    tokio::spawn(create_tcp_server_task_impl(
-        rx,
-        max_sessions,
-        addr,
-        listener,
-        handlers,
-        decode,
-    ));
+
+    let task = async move {
+        ServerTask::new(
+            max_sessions,
+            listener,
+            handlers,
+            TcpServerConnectionHandler::Tcp,
+            decode,
+        )
+        .run(rx)
+        .instrument(tracing::info_span!("Modbus-Server-TCP", "listen" = ?addr))
+        .await;
+    };
+
+    tokio::spawn(task);
 
     Ok(ServerHandle::new(tx))
 }
 
-/// Creates a TCP server task that can then be spawned onto the runtime manually.
-/// Most users will prefer [`spawn_tcp_server_task`] unless they are using the library from
-/// outside the Tokio runtime and need to spawn it using a Runtime handle instead of the
-/// `tokio::spawn` function.
-///
-/// Each incoming connection will spawn a new task to handle it.
-///
-/// * `max_sessions` - Maximum number of concurrent sessions
-/// * `addr` - A socket address to bound to
-/// * `handlers` - A map of handlers keyed by a unit id
-/// * `decode` - Decode log level
-pub async fn create_tcp_server_task<T: RequestHandler>(
-    rx: tokio::sync::mpsc::Receiver<ServerSetting>,
-    max_sessions: usize,
-    addr: SocketAddr,
-    handlers: ServerHandlerMap<T>,
-    decode: DecodeLevel,
-) -> Result<impl std::future::Future<Output = ()>, std::io::Error> {
-    let listener = tokio::net::TcpListener::bind(addr).await?;
-    Ok(create_tcp_server_task_impl(
-        rx,
-        max_sessions,
-        addr,
-        listener,
-        handlers,
-        decode,
-    ))
-}
-
-async fn create_tcp_server_task_impl<T: RequestHandler>(
-    rx: tokio::sync::mpsc::Receiver<ServerSetting>,
-    max_sessions: usize,
-    addr: SocketAddr,
-    listener: tokio::net::TcpListener,
-    handlers: ServerHandlerMap<T>,
-    decode: DecodeLevel,
-) {
-    ServerTask::new(
-        max_sessions,
-        listener,
-        handlers,
-        TcpServerConnectionHandler::Tcp,
-        decode,
-    )
-    .run(rx)
-    .instrument(tracing::info_span!("Modbus-Server-TCP", "listen" = ?addr))
-    .await;
-}
-
 /// Spawns a RTU server task onto the runtime. This method can only
-/// be called from within the runtime context. Use [`create_rtu_server_task`]
-/// and then spawn it manually if using outside the Tokio runtime.
+/// be called from within the runtime context. Use `Runtime::enter()`
+/// to create a context on the current thread if necessary.
 ///
 /// * `path` - Path to the serial device. Generally `/dev/tty0` on Linux and `COM1` on Windows.
 /// * `serial_settings` = Serial port settings
@@ -148,70 +105,32 @@ pub fn spawn_rtu_server_task<T: RequestHandler>(
     let serial = crate::serial::open(path, settings)?;
 
     let (tx, rx) = tokio::sync::mpsc::channel(SERVER_SETTING_CHANNEL_CAPACITY);
-    tokio::spawn(create_rtu_server_task_impl(
-        rx,
-        path.to_string(),
-        serial,
-        handlers,
-        decode,
-    ));
+
+    let phys = PhysLayer::new_serial(serial);
+    let path = path.to_string();
+    let task = async move {
+        SessionTask::new(
+            phys,
+            handlers,
+            Authorization::None,
+            FrameWriter::rtu(),
+            FramedReader::rtu_request(),
+            rx,
+            decode,
+        )
+        .run()
+        .instrument(tracing::info_span!("Modbus-Server-RTU", "port" = ?path))
+        .await
+    };
+
+    tokio::spawn(task);
 
     Ok(ServerHandle::new(tx))
 }
 
-/// Creates a TCP server task that can then be spawned onto the runtime manually.
-/// Most users will prefer [`spawn_rtu_server_task`] unless they are using the library from
-/// outside the Tokio runtime and need to spawn it using a Runtime handle instead of the
-/// `tokio::spawn` function.
-///
-/// * `path` - Path to the serial device. Generally `/dev/tty0` on Linux and `COM1` on Windows.
-/// * `serial_settings` = Serial port settings
-/// * `handlers` - A map of handlers keyed by a unit id
-/// * `decode` - Decode log level
-pub fn create_rtu_server_task<T: RequestHandler>(
-    rx: tokio::sync::mpsc::Receiver<ServerSetting>,
-    path: &str,
-    settings: SerialSettings,
-    handlers: ServerHandlerMap<T>,
-    decode: DecodeLevel,
-) -> Result<impl std::future::Future<Output = ()>, std::io::Error> {
-    let serial = crate::serial::open(path, settings)?;
-
-    Ok(create_rtu_server_task_impl(
-        rx,
-        path.to_string(),
-        serial,
-        handlers,
-        decode,
-    ))
-}
-
-async fn create_rtu_server_task_impl<T: RequestHandler>(
-    rx: tokio::sync::mpsc::Receiver<ServerSetting>,
-    path: String,
-    serial_stream: SerialStream,
-    handlers: ServerHandlerMap<T>,
-    decode: DecodeLevel,
-) {
-    let phys = PhysLayer::new_serial(serial_stream);
-    let mut task = SessionTask::new(
-        phys,
-        handlers,
-        Authorization::None,
-        FrameWriter::rtu(),
-        FramedReader::rtu_request(),
-        rx,
-        decode,
-    );
-
-    task.run()
-        .instrument(tracing::info_span!("Modbus-Server-RTU", "port" = ?path))
-        .await;
-}
-
 /// Spawns a TLS server task onto the runtime. This method can only
-/// be called from within the runtime context. Use [`create_tls_server_task`]
-/// and then spawn it manually if using outside the Tokio runtime.
+/// be called from within the runtime context. Use `Runtime::enter()`
+/// to create a context on the current thread if necessary.
 ///
 /// Each incoming connection will spawn a new task to handle it.
 ///
@@ -233,76 +152,21 @@ pub async fn spawn_tls_server_task<T: RequestHandler>(
     let listener = tokio::net::TcpListener::bind(addr).await?;
 
     let (tx, rx) = tokio::sync::mpsc::channel(SERVER_SETTING_CHANNEL_CAPACITY);
-    tokio::spawn(create_tls_server_task_impl(
-        rx,
-        max_sessions,
-        addr,
-        listener,
-        handlers,
-        auth_handler,
-        tls_config,
-        decode,
-    ));
+
+    let task = async move {
+        ServerTask::new(
+            max_sessions,
+            listener,
+            handlers,
+            TcpServerConnectionHandler::Tls(tls_config, auth_handler),
+            decode,
+        )
+        .run(rx)
+        .instrument(tracing::info_span!("Modbus-Server-TLS", "listen" = ?addr))
+        .await
+    };
+
+    tokio::spawn(task);
 
     Ok(ServerHandle::new(tx))
-}
-
-/// Creates a TLS server task that can then be spawned onto the runtime manually.
-/// Most users will prefer [`spawn_tcp_server_task`] unless they are using the library from
-/// outside the Tokio runtime and need to spawn it using a Runtime handle instead of the
-/// `tokio::spawn` function.
-///
-/// Each incoming connection will spawn a new task to handle it.
-///
-/// * `max_sessions` - Maximum number of concurrent sessions
-/// * `addr` - A socket address to bound to
-/// * `handlers` - A map of handlers keyed by a unit id
-/// * `auth_handler` - Authorization handler
-/// * `tls_config` - TLS configuration
-/// * `decode` - Decode log level
-#[cfg(feature = "tls")]
-pub async fn create_tls_server_task<T: RequestHandler>(
-    rx: tokio::sync::mpsc::Receiver<ServerSetting>,
-    max_sessions: usize,
-    addr: SocketAddr,
-    handlers: ServerHandlerMap<T>,
-    auth_handler: std::sync::Arc<dyn AuthorizationHandler>,
-    tls_config: TlsServerConfig,
-    decode: DecodeLevel,
-) -> Result<impl std::future::Future<Output = ()>, std::io::Error> {
-    let listener = tokio::net::TcpListener::bind(addr).await?;
-    Ok(create_tls_server_task_impl(
-        rx,
-        max_sessions,
-        addr,
-        listener,
-        handlers,
-        auth_handler,
-        tls_config,
-        decode,
-    ))
-}
-
-#[cfg(feature = "tls")]
-#[allow(clippy::too_many_arguments)]
-async fn create_tls_server_task_impl<T: RequestHandler>(
-    rx: tokio::sync::mpsc::Receiver<ServerSetting>,
-    max_sessions: usize,
-    addr: SocketAddr,
-    listener: tokio::net::TcpListener,
-    handlers: ServerHandlerMap<T>,
-    auth_handler: std::sync::Arc<dyn AuthorizationHandler>,
-    tls_config: TlsServerConfig,
-    decode: DecodeLevel,
-) {
-    ServerTask::new(
-        max_sessions,
-        listener,
-        handlers,
-        TcpServerConnectionHandler::Tls(tls_config, auth_handler),
-        decode,
-    )
-    .run(rx)
-    .instrument(tracing::info_span!("Modbus-Server-TLS", "listen" = ?addr))
-    .await;
 }


### PR DESCRIPTION
Fixes https://github.com/stepfunc/rodbus/issues/74.

Removes non-spawning functions from the public Rust API and uses `Runtime::enter` instead.