### PR TITLE
make tokio-serial an optional dependency for the core crate

### DIFF
--- a/ffi/rodbus-ffi-java/Cargo.toml
+++ b/ffi/rodbus-ffi-java/Cargo.toml
@@ -10,7 +10,12 @@ crate-type = ["cdylib"]
 
 [dependencies]
 jni = "0.19"
-rodbus-ffi = { path = "../rodbus-ffi" }
+rodbus-ffi = { path = "../rodbus-ffi", default-features = false }
+
+[features]
+default = ["serial", "tls"]
+serial = ["rodbus-ffi/serial"]
+tls = ["rodbus-ffi/tls"]
 
 [build-dependencies]
 rodbus-schema = { path = "../rodbus-schema" }

--- a/ffi/rodbus-ffi/Cargo.toml
+++ b/ffi/rodbus-ffi/Cargo.toml
@@ -17,7 +17,7 @@ lazy_static = "1.0"
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-subscriber = "0.2"
-rodbus = { path = "../../rodbus", features = ["tls"] }
+rodbus = { path = "../../rodbus", features = ["tls", "serial"] }
 tokio = { version = "1.5", features = ["rt-multi-thread"]}
 num_cpus = "1"
 

--- a/ffi/rodbus-ffi/Cargo.toml
+++ b/ffi/rodbus-ffi/Cargo.toml
@@ -17,10 +17,15 @@ lazy_static = "1.0"
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-subscriber = "0.2"
-rodbus = { path = "../../rodbus", features = ["tls", "serial"] }
+rodbus = { path = "../../rodbus", default-features = false }
 tokio = { version = "1.5", features = ["rt-multi-thread"]}
 num_cpus = "1"
 
 [build-dependencies]
 rodbus-schema = { path = "../rodbus-schema" }
 rust-oo-bindgen = { git = "https://github.com/stepfunc/oo_bindgen.git", tag = "0.2.1" }
+
+[features]
+default = ["serial", "tls"]
+serial = ["rodbus/serial"]
+tls = ["rodbus/tls"]

--- a/ffi/rodbus-ffi/src/helpers/conversions.rs
+++ b/ffi/rodbus-ffi/src/helpers/conversions.rs
@@ -1,4 +1,4 @@
-use rodbus::client::{CertificateMode, MinTlsVersion, ReconnectStrategy, TlsError};
+use rodbus::client::ReconnectStrategy;
 use rodbus::error::Shutdown;
 use rodbus::server::Authorization;
 use rodbus::AddressRange;
@@ -75,6 +75,7 @@ impl From<AddressRange> for ffi::AddressRange {
     }
 }
 
+#[cfg(feature = "tls")]
 impl From<ffi::SerialPortSettings> for rodbus::serial::SerialSettings {
     fn from(from: ffi::SerialPortSettings) -> Self {
         Self {
@@ -112,32 +113,39 @@ impl From<ffi::Authorization> for Authorization {
     }
 }
 
-impl From<TlsError> for ffi::ParamError {
-    fn from(error: TlsError) -> Self {
+#[cfg(feature = "tls")]
+impl From<rodbus::client::TlsError> for ffi::ParamError {
+    fn from(error: rodbus::client::TlsError) -> Self {
         match error {
-            TlsError::InvalidDnsName => ffi::ParamError::InvalidDnsName,
-            TlsError::InvalidPeerCertificate(_) => ffi::ParamError::InvalidPeerCertificate,
-            TlsError::InvalidLocalCertificate(_) => ffi::ParamError::InvalidLocalCertificate,
-            TlsError::InvalidPrivateKey(_) => ffi::ParamError::InvalidPrivateKey,
-            TlsError::BadConfig(_) => ffi::ParamError::BadTlsConfig,
+            rodbus::client::TlsError::InvalidDnsName => ffi::ParamError::InvalidDnsName,
+            rodbus::client::TlsError::InvalidPeerCertificate(_) => {
+                ffi::ParamError::InvalidPeerCertificate
+            }
+            rodbus::client::TlsError::InvalidLocalCertificate(_) => {
+                ffi::ParamError::InvalidLocalCertificate
+            }
+            rodbus::client::TlsError::InvalidPrivateKey(_) => ffi::ParamError::InvalidPrivateKey,
+            rodbus::client::TlsError::BadConfig(_) => ffi::ParamError::BadTlsConfig,
         }
     }
 }
 
-impl From<ffi::MinTlsVersion> for MinTlsVersion {
+#[cfg(feature = "tls")]
+impl From<ffi::MinTlsVersion> for rodbus::client::MinTlsVersion {
     fn from(from: ffi::MinTlsVersion) -> Self {
         match from {
-            ffi::MinTlsVersion::V12 => MinTlsVersion::V1_2,
-            ffi::MinTlsVersion::V13 => MinTlsVersion::V1_3,
+            ffi::MinTlsVersion::V12 => rodbus::client::MinTlsVersion::V1_2,
+            ffi::MinTlsVersion::V13 => rodbus::client::MinTlsVersion::V1_3,
         }
     }
 }
 
-impl From<ffi::CertificateMode> for CertificateMode {
+#[cfg(feature = "tls")]
+impl From<ffi::CertificateMode> for rodbus::client::CertificateMode {
     fn from(from: ffi::CertificateMode) -> Self {
         match from {
-            ffi::CertificateMode::AuthorityBased => CertificateMode::AuthorityBased,
-            ffi::CertificateMode::SelfSigned => CertificateMode::SelfSigned,
+            ffi::CertificateMode::AuthorityBased => rodbus::client::CertificateMode::AuthorityBased,
+            ffi::CertificateMode::SelfSigned => rodbus::client::CertificateMode::SelfSigned,
         }
     }
 }

--- a/ffi/rodbus-ffi/src/lib.rs
+++ b/ffi/rodbus-ffi/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::all)]
+#![allow(dead_code)]
 
 mod client;
 mod database;

--- a/ffi/rodbus-schema/Cargo.toml
+++ b/ffi/rodbus-schema/Cargo.toml
@@ -12,4 +12,4 @@ readme = "../README.md"
 
 [dependencies]
 oo-bindgen = { git = "https://github.com/stepfunc/oo_bindgen.git", tag = "0.2.1" }
-rodbus = { path = "../../rodbus" }
+rodbus = { path = "../../rodbus", default-features = false }

--- a/ffi/rodbus-schema/src/common.rs
+++ b/ffi/rodbus-schema/src/common.rs
@@ -53,6 +53,10 @@ fn build_error_type(lib: &mut LibraryBuilder) -> BackTraced<ErrorTypeHandle> {
             "param_exception",
             ExceptionType::UncheckedException,
         )?
+        .add_error(
+            "no_support",
+            "The FFI library was compiled without support for this feature",
+        )?
         .add_error("null_parameter", "Null parameter")?
         .add_error(
             "logging_already_configured",

--- a/rodbus/Cargo.toml
+++ b/rodbus/Cargo.toml
@@ -12,7 +12,6 @@ readme = "../README.md"
 [dependencies]
 crc = "2.0"
 tokio = { version = "1", features = ["net", "sync", "io-util", "io-std", "time", "rt", "rt-multi-thread", "macros"] }
-tokio-serial = "5.4"
 tracing = "0.1"
 
 # TLS dependencies
@@ -20,6 +19,7 @@ pem = { version = "1.0", optional = true }
 pkcs8 = { version = "0.7", features = ["encryption", "pem", "std"], optional = true }
 rasn = { git = "https://github.com/stepfunc/rasn.git", tag = "0.1.2", optional = true }
 tokio-rustls = { version = "0.23", features = ["dangerous_configuration", "tls12"], default-features = false, optional = true }
+tokio-serial = { version = "5.4", default-features = false, optional = true }
 
 [dev-dependencies]
 tokio-stream = "0.1"
@@ -29,5 +29,6 @@ tokio-mock-io = { git = "https://github.com/stepfunc/tokio-mock-io.git", tag = "
 tracing-subscriber = "0.2"
 
 [features]
-default = ["tls"]
+default = ["tls", "serial"]
 tls = ["pem", "pkcs8", "rasn", "tokio-rustls"]
+serial = ["tokio-serial"]

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 use std::net::{IpAddr, Ipv4Addr};
-use std::path::Path;
 use std::process::exit;
 use std::time::Duration;
 
@@ -8,6 +7,7 @@ use tokio_stream::StreamExt;
 use tokio_util::codec::{FramedRead, LinesCodec};
 
 use rodbus::client::*;
+#[cfg(feature = "serial")]
 use rodbus::serial::*;
 use rodbus::*;
 
@@ -34,6 +34,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     };
     match transport {
         "tcp" => run_tcp().await,
+        #[cfg(feature = "serial")]
         "rtu" => run_rtu().await,
         #[cfg(feature = "tls")]
         "tls-ca" => run_tls(get_ca_chain_config()?).await,
@@ -74,6 +75,7 @@ async fn run_tcp() -> Result<(), Box<dyn std::error::Error>> {
     run_channel(channel).await
 }
 
+#[cfg(feature = "serial")]
 async fn run_rtu() -> Result<(), Box<dyn std::error::Error>> {
     // ANCHOR: create_rtu_channel
     let channel = spawn_rtu_client_task(
@@ -115,6 +117,7 @@ async fn run_tls(tls_config: TlsClientConfig) -> Result<(), Box<dyn std::error::
 
 #[cfg(feature = "tls")]
 fn get_self_signed_config() -> Result<TlsClientConfig, Box<dyn std::error::Error>> {
+    use std::path::Path;
     // ANCHOR: tls_self_signed_config
     let tls_config = TlsClientConfig::new(
         "test.com",
@@ -132,6 +135,7 @@ fn get_self_signed_config() -> Result<TlsClientConfig, Box<dyn std::error::Error
 
 #[cfg(feature = "tls")]
 fn get_ca_chain_config() -> Result<TlsClientConfig, Box<dyn std::error::Error>> {
+    use std::path::Path;
     // ANCHOR: tls_ca_chain_config
     let tls_config = TlsClientConfig::new(
         "test.com",

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -7,8 +7,6 @@ use tokio_stream::StreamExt;
 use tokio_util::codec::{FramedRead, LinesCodec};
 
 use rodbus::client::*;
-#[cfg(feature = "serial")]
-use rodbus::serial::*;
 use rodbus::*;
 
 // ANCHOR: runtime_init
@@ -79,10 +77,10 @@ async fn run_tcp() -> Result<(), Box<dyn std::error::Error>> {
 async fn run_rtu() -> Result<(), Box<dyn std::error::Error>> {
     // ANCHOR: create_rtu_channel
     let channel = spawn_rtu_client_task(
-        "/dev/ttySIM0",            // path
-        SerialSettings::default(), // serial settings
-        1,                         // max queued requests
-        Duration::from_secs(1),    // retry delay
+        "/dev/ttySIM0",                            // path
+        rodbus::serial::SerialSettings::default(), // serial settings
+        1,                                         // max queued requests
+        Duration::from_secs(1),                    // retry delay
         DecodeLevel::new(
             AppDecodeLevel::DataValues,
             FrameDecodeLevel::Payload,

--- a/rodbus/examples/server.rs
+++ b/rodbus/examples/server.rs
@@ -1,9 +1,9 @@
-use std::path::Path;
 use std::process::exit;
 
 use tokio_stream::StreamExt;
 use tokio_util::codec::{FramedRead, LinesCodec};
 
+#[cfg(feature = "serial")]
 use rodbus::serial::*;
 use rodbus::server::*;
 use rodbus::*;
@@ -148,6 +148,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     match transport {
         "tcp" => run_tcp().await,
+        #[cfg(feature = "serial")]
         "rtu" => run_rtu().await,
         #[cfg(feature = "tls")]
         "tls-ca" => run_tls(get_ca_chain_config()?).await,
@@ -180,6 +181,7 @@ async fn run_tcp() -> Result<(), Box<dyn std::error::Error>> {
     run_server(server, handler).await
 }
 
+#[cfg(feature = "serial")]
 async fn run_rtu() -> Result<(), Box<dyn std::error::Error>> {
     let (handler, map) = create_handler();
 
@@ -236,6 +238,7 @@ fn create_handler() -> (
 
 #[cfg(feature = "tls")]
 fn get_self_signed_config() -> Result<TlsServerConfig, Box<dyn std::error::Error>> {
+    use std::path::Path;
     // ANCHOR: tls_self_signed_config
     let tls_config = TlsServerConfig::new(
         &Path::new("./certs/self_signed/entity1_cert.pem"),
@@ -252,6 +255,7 @@ fn get_self_signed_config() -> Result<TlsServerConfig, Box<dyn std::error::Error
 
 #[cfg(feature = "tls")]
 fn get_ca_chain_config() -> Result<TlsServerConfig, Box<dyn std::error::Error>> {
+    use std::path::Path;
     // ANCHOR: tls_ca_chain_config
     let tls_config = TlsServerConfig::new(
         &Path::new("./certs/ca_chain/ca_cert.pem"),

--- a/rodbus/examples/server.rs
+++ b/rodbus/examples/server.rs
@@ -3,8 +3,6 @@ use std::process::exit;
 use tokio_stream::StreamExt;
 use tokio_util::codec::{FramedRead, LinesCodec};
 
-#[cfg(feature = "serial")]
-use rodbus::serial::*;
 use rodbus::server::*;
 use rodbus::*;
 
@@ -188,7 +186,7 @@ async fn run_rtu() -> Result<(), Box<dyn std::error::Error>> {
     // ANCHOR: rtu_server_create
     let server = rodbus::server::spawn_rtu_server_task(
         "/dev/ttySIM1",
-        SerialSettings::default(),
+        rodbus::serial::SerialSettings::default(),
         map,
         DecodeLevel::new(
             AppDecodeLevel::DataValues,

--- a/rodbus/src/client/listener.rs
+++ b/rodbus/src/client/listener.rs
@@ -43,6 +43,7 @@ pub enum ClientState {
 }
 
 /// state of the serial port
+#[cfg(feature = "serial")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum PortState {
     /// disabled and idle until enabled

--- a/rodbus/src/client/mod.rs
+++ b/rodbus/src/client/mod.rs
@@ -1,8 +1,6 @@
 use std::net::{IpAddr, SocketAddr};
-use std::time::Duration;
 
 use crate::decode::DecodeLevel;
-use crate::serial::SerialSettings;
 
 /// persistent communication channel such as a TCP connection
 pub(crate) mod channel;
@@ -109,11 +107,12 @@ pub fn spawn_tcp_client_task(
 /// * `max_queued_requests` - The maximum size of the request queue
 /// * `retry` - Delay between attempts to open the serial port
 /// * `decode` - Decode log level
+#[cfg(feature = "serial")]
 pub fn spawn_rtu_client_task(
     path: &str,
-    serial_settings: SerialSettings,
+    serial_settings: crate::serial::SerialSettings,
     max_queued_requests: usize,
-    retry_delay: Duration,
+    retry_delay: std::time::Duration,
     decode: DecodeLevel,
     listener: Option<Box<dyn Listener<PortState>>>,
 ) -> Channel {

--- a/rodbus/src/common/buffer.rs
+++ b/rodbus/src/common/buffer.rs
@@ -61,6 +61,7 @@ impl ReadBuffer {
     }
 
     #[cfg_attr(feature = "no-panic", no_panic)]
+    #[cfg(feature = "serial")]
     pub(crate) fn peek_at(&mut self, idx: usize) -> Result<u8, InternalError> {
         let len = self.len();
         if len < idx {
@@ -80,6 +81,7 @@ impl ReadBuffer {
     }
 
     #[cfg_attr(feature = "no-panic", no_panic)]
+    #[cfg(feature = "serial")]
     pub(crate) fn read_u16_le(&mut self) -> Result<u16, InternalError> {
         let b1 = self.read_u8()? as u16;
         let b2 = self.read_u8()? as u16;

--- a/rodbus/src/common/cursor.rs
+++ b/rodbus/src/common/cursor.rs
@@ -80,6 +80,7 @@ impl<'a> ReadCursor<'a> {
 
 impl<'a> WriteCursor<'a> {
     #[cfg_attr(feature = "no-panic", no_panic)]
+    #[cfg(feature = "serial")]
     pub(crate) fn get(&self, range: Range<usize>) -> Option<&[u8]> {
         self.dest.get(range)
     }
@@ -142,6 +143,7 @@ impl<'a> WriteCursor<'a> {
     }
 
     #[cfg_attr(feature = "no-panic", no_panic)]
+    #[cfg(feature = "serial")]
     pub(crate) fn write_u16_le(&mut self, value: u16) -> Result<(), InternalError> {
         if self.remaining() < 2 {
             // don't write any bytes if there's isn't space for the whole thing

--- a/rodbus/src/lib.rs
+++ b/rodbus/src/lib.rs
@@ -197,6 +197,7 @@ pub mod constants;
 /// Error types associated with making requests
 pub mod error;
 /// Serial (RTU) API
+#[cfg(feature = "serial")]
 pub mod serial;
 /// Server API
 pub mod server;

--- a/rodbus/src/tcp/client.rs
+++ b/rodbus/src/tcp/client.rs
@@ -60,12 +60,12 @@ impl TcpTaskConnectionHandler {
     async fn handle(
         &mut self,
         socket: TcpStream,
-        endpoint: &HostAddr,
+        _endpoint: &HostAddr,
     ) -> Result<PhysLayer, String> {
         match self {
             Self::Tcp => Ok(PhysLayer::new_tcp(socket)),
             #[cfg(feature = "tls")]
-            Self::Tls(config) => config.handle_connection(socket, endpoint).await,
+            Self::Tls(config) => config.handle_connection(socket, _endpoint).await,
         }
     }
 }

--- a/rodbus/src/tcp/server.rs
+++ b/rodbus/src/tcp/server.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::sync::Arc;
 
 use tracing::Instrument;
 
@@ -75,7 +74,7 @@ pub(crate) enum TcpServerConnectionHandler {
     #[cfg(feature = "tls")]
     Tls(
         crate::tcp::tls::TlsServerConfig,
-        Option<Arc<dyn AuthorizationHandler>>,
+        Option<std::sync::Arc<dyn AuthorizationHandler>>,
     ),
 }
 


### PR DESCRIPTION
Makes serial optional in rodbus in addition to TLS.

Makes serial and TLS optional when compiling the FFI and JNI libraries.