### PR TITLE
Fault-tolerant RTU server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "rodbus"
-version = "1.0.0-alpha9"
+version = "1.0.0-alpha10"
 dependencies = [
  "crc",
  "pem",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "rodbus-bindings"
-version = "1.0.0-alpha9"
+version = "1.0.0-alpha10"
 dependencies = [
  "ci-script",
  "rodbus-schema",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "rodbus-client"
-version = "1.0.0-alpha9"
+version = "1.0.0-alpha10"
 dependencies = [
  "clap",
  "rodbus",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "rodbus-ffi"
-version = "1.0.0-alpha9"
+version = "1.0.0-alpha10"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "rodbus-ffi-java"
-version = "1.0.0-alpha9"
+version = "1.0.0-alpha10"
 dependencies = [
  "java-oo-bindgen",
  "jni",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "rodbus-schema"
-version = "1.0.0-alpha9"
+version = "1.0.0-alpha10"
 dependencies = [
  "oo-bindgen",
 ]

--- a/ffi/bindings/c/CMakeLists.txt
+++ b/ffi/bindings/c/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(rodbus_c LANGUAGES C CXX)
 
-set(RODBUS_VERSION "1.0.0-alpha9")
+set(RODBUS_VERSION "1.0.0-alpha10")
 
 # Determine the architecture
 if(WIN32 AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64" AND CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/ffi/bindings/c/server_example.c
+++ b/ffi/bindings/c/server_example.c
@@ -219,7 +219,7 @@ int run_rtu_channel(rodbus_runtime_t* runtime)
     rodbus_server_t* server = NULL;
     rodbus_device_map_t* map = build_device_map();
     rodbus_decode_level_t decode_level = rodbus_decode_level_nothing();
-    rodbus_param_error_t err = rodbus_server_create_rtu(runtime, "/dev/ttySIM1", rodbus_serial_port_settings_init(), map, decode_level, &server);
+    rodbus_param_error_t err = rodbus_server_create_rtu(runtime, "/dev/ttySIM1", rodbus_serial_port_settings_init(), 3000, map, decode_level, &server);
     rodbus_device_map_destroy(map);
 
     if (err) {

--- a/ffi/bindings/c/server_example.cpp
+++ b/ffi/bindings/c/server_example.cpp
@@ -223,7 +223,7 @@ int run_rtu_server(rodbus::Runtime& runtime)
     auto device_map = create_device_map();
 
     // ANCHOR: rtu_server_create
-    auto server = rodbus::Server::create_rtu(runtime, "/dev/ttySIM1", rodbus::SerialPortSettings(), device_map, rodbus::DecodeLevel::nothing());
+    auto server = rodbus::Server::create_rtu(runtime, "/dev/ttySIM1", rodbus::SerialPortSettings(), std::chrono::seconds(3), device_map, rodbus::DecodeLevel::nothing());
     // ANCHOR_END: rtu_server_create
 
     return run_server(server);

--- a/ffi/bindings/dotnet/examples/client/client.csproj
+++ b/ffi/bindings/dotnet/examples/client/client.csproj
@@ -13,7 +13,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="rodbus" Version="1.0.0-alpha9" />
+        <PackageReference Include="rodbus" Version="1.0.0-alpha10" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/ffi/bindings/dotnet/examples/server/Program.cs
+++ b/ffi/bindings/dotnet/examples/server/Program.cs
@@ -196,7 +196,7 @@ namespace example
         private static Server CreateRtuServer(Runtime runtime, DeviceMap map)
         {
             // ANCHOR: rtu_server_create            
-            var server = Server.CreateRtu(runtime, "/dev/ttySIM1", new SerialPortSettings(), map, DecodeLevel.Nothing());
+            var server = Server.CreateRtu(runtime, "/dev/ttySIM1", new SerialPortSettings(), TimeSpan.FromSeconds(3), map, DecodeLevel.Nothing());
             // ANCHOR_END: rtu_server_create
 
             return server;

--- a/ffi/bindings/dotnet/examples/server/server.csproj
+++ b/ffi/bindings/dotnet/examples/server/server.csproj
@@ -13,7 +13,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="rodbus" Version="1.0.0-alpha9" />
+        <PackageReference Include="rodbus" Version="1.0.0-alpha10" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/ffi/bindings/java/examples/pom.xml
+++ b/ffi/bindings/java/examples/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>io.stepfunc</groupId>
             <artifactId>rodbus</artifactId>
-            <version>1.0.0-alpha9</version>
+            <version>1.0.0-alpha10</version>
         </dependency>
     </dependencies>
 </project>

--- a/ffi/bindings/java/examples/src/main/java/io/stepfunc/rodbus/examples/ServerExample.java
+++ b/ffi/bindings/java/examples/src/main/java/io/stepfunc/rodbus/examples/ServerExample.java
@@ -169,7 +169,7 @@ public class ServerExample {
 
     private static Server createRtuServer(Runtime runtime, DeviceMap map) {
         // ANCHOR: rtu_server_create
-        Server server = Server.createRtu(runtime, "/dev/ttySIM1", new SerialPortSettings(), map, DecodeLevel.nothing());
+        Server server = Server.createRtu(runtime, "/dev/ttySIM1", new SerialPortSettings(), Duration.ofSeconds(3), map, DecodeLevel.nothing());
         // ANCHOR_END: rtu_server_create
 
         return server;

--- a/ffi/bindings/java/rodbus-tests/pom.xml
+++ b/ffi/bindings/java/rodbus-tests/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>io.stepfunc</groupId>
             <artifactId>rodbus</artifactId>
-            <version>1.0.0-alpha9</version>
+            <version>1.0.0-alpha10</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/ffi/rodbus-bindings/Cargo.toml
+++ b/ffi/rodbus-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodbus-bindings"
-version = "1.0.0-alpha9"
+version = "1.0.0-alpha10"
 authors = ["Step Function I/O LLC <info@stepfunc.io>"]
 edition = "2021"
 license = "GPL-3.0-only"

--- a/ffi/rodbus-ffi-java/Cargo.toml
+++ b/ffi/rodbus-ffi-java/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodbus-ffi-java"
-version = "1.0.0-alpha9"
+version = "1.0.0-alpha10"
 authors = ["Step Function I/O LLC <info@stepfunc.io>"]
 edition = "2021"
 build = "build.rs"

--- a/ffi/rodbus-ffi/Cargo.toml
+++ b/ffi/rodbus-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodbus-ffi"
-version = "1.0.0-alpha9"
+version = "1.0.0-alpha10"
 authors = ["Step Function I/O LLC <info@stepfunc.io>"]
 edition = "2021"
 description = "FFI for Rodbus"

--- a/ffi/rodbus-ffi/src/server.rs
+++ b/ffi/rodbus-ffi/src/server.rs
@@ -329,6 +329,7 @@ pub(crate) unsafe fn server_create_rtu(
     runtime: *mut crate::Runtime,
     path: &std::ffi::CStr,
     serial_params: ffi::SerialPortSettings,
+    port_retry_delay: std::time::Duration,
     endpoints: *mut crate::DeviceMap,
     decode_level: ffi::DecodeLevel,
 ) -> Result<*mut crate::Server, ffi::ParamError> {
@@ -342,6 +343,7 @@ pub(crate) unsafe fn server_create_rtu(
     let handle = rodbus::server::spawn_rtu_server_task(
         &path.to_string_lossy(),
         serial_params.into(),
+        port_retry_delay,
         handler_map.clone(),
         decode_level.into(),
     )

--- a/ffi/rodbus-schema/Cargo.toml
+++ b/ffi/rodbus-schema/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rodbus-schema"
 # this is the version that all the FFI libraries get, since it's in their schema
-version = "1.0.0-alpha9"
+version = "1.0.0-alpha10"
 authors = ["Step Function I/O LLC <info@stepfunc.io>"]
 edition = "2021"
 license = "GPL-3.0-only"

--- a/ffi/rodbus-schema/src/server.rs
+++ b/ffi/rodbus-schema/src/server.rs
@@ -85,6 +85,11 @@ pub(crate) fn build_server(
             "Serial port settings",
         )?
         .param(
+            "port_retry_delay",
+            DurationType::Milliseconds,
+            "How long to wait before re-opening the serial port",
+        )?
+        .param(
             "endpoints",
             handler_map.declaration.clone(),
             "map of endpoints which is emptied upon passing to this function",

--- a/guide/sitedata.json
+++ b/guide/sitedata.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.0.0-alpha9",
+    "version": "1.0.0-alpha10",
     "github_url": "https://github.com/stepfunc/rodbus"
 }

--- a/rodbus-client/Cargo.toml
+++ b/rodbus-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodbus-client"
-version = "1.0.0-alpha9"
+version = "1.0.0-alpha10"
 authors = ["Step Function I/O LLC <info@stepfunc.io>>"]
 edition = "2021"
 description = "A command line program for making Modbus client requests using the Rodbus crate"
@@ -14,7 +14,7 @@ name = "rodbus-client"
 path = "src/main.rs"
 
 [dependencies]
-rodbus = { path = "../rodbus", version = "1.0.0-alpha9", default-features = false }
+rodbus = { path = "../rodbus", version = "1.0.0-alpha10", default-features = false }
 clap = "2.33"
 tokio = { version = "1", features = ["macros", "time"] }
 tracing = "0.1"

--- a/rodbus/Cargo.toml
+++ b/rodbus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodbus"
-version = "1.0.0-alpha9"
+version = "1.0.0-alpha10"
 authors = ["Step Function I/O LLC <info@stepfunc.io>"]
 edition = "2021"
 description = "A high-performance async implementation of the Modbus protocol using tokio"

--- a/rodbus/examples/server.rs
+++ b/rodbus/examples/server.rs
@@ -1,4 +1,5 @@
 use std::process::exit;
+use std::time::Duration;
 
 use tokio_stream::StreamExt;
 use tokio_util::codec::{FramedRead, LinesCodec};
@@ -187,6 +188,7 @@ async fn run_rtu() -> Result<(), Box<dyn std::error::Error>> {
     let server = rodbus::server::spawn_rtu_server_task(
         "/dev/ttySIM1",
         rodbus::SerialSettings::default(),
+        Duration::from_secs(3),
         map,
         DecodeLevel::new(
             AppDecodeLevel::DataValues,

--- a/rodbus/src/serial/mod.rs
+++ b/rodbus/src/serial/mod.rs
@@ -3,6 +3,7 @@ pub use tokio_serial::{DataBits, FlowControl, Parity, StopBits};
 
 pub(crate) mod client;
 pub(crate) mod frame;
+pub(crate) mod server;
 
 /// serial port settings
 #[derive(Copy, Clone, Debug)]

--- a/rodbus/src/serial/server.rs
+++ b/rodbus/src/serial/server.rs
@@ -31,7 +31,7 @@ where
                 }
                 Err(err) => {
                     tracing::warn!(
-                        "Unable to open serial port, retrying in {:?} - error: {}",
+                        "unable to open serial port, retrying in {:?} - error: {}",
                         self.port_retry_delay,
                         err
                     );

--- a/rodbus/src/serial/server.rs
+++ b/rodbus/src/serial/server.rs
@@ -1,0 +1,44 @@
+use crate::common::phys::PhysLayer;
+use crate::server::task::SessionTask;
+use crate::server::RequestHandler;
+use crate::{RequestError, SerialSettings, Shutdown};
+use std::time::Duration;
+
+pub(crate) struct RtuServerTask<T>
+where
+    T: RequestHandler,
+{
+    pub(crate) port: String,
+    pub(crate) port_retry_delay: Duration,
+    pub(crate) settings: SerialSettings,
+    pub(crate) session: SessionTask<T>,
+}
+
+impl<T> RtuServerTask<T>
+where
+    T: RequestHandler,
+{
+    pub(crate) async fn run(&mut self) -> Shutdown {
+        loop {
+            match crate::serial::open(&self.port, self.settings) {
+                Ok(serial) => {
+                    // run an open port until shutdown or failure
+                    let mut phys = PhysLayer::new_serial(serial);
+                    if let RequestError::Shutdown = self.session.run(&mut phys).await {
+                        return Shutdown;
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "Unable to open serial port, retrying in {:?} - error: {}",
+                        self.port_retry_delay,
+                        err
+                    );
+                    if let Err(Shutdown) = self.session.sleep_for(self.port_retry_delay).await {
+                        return Shutdown;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/rodbus/src/serial/server.rs
+++ b/rodbus/src/serial/server.rs
@@ -28,6 +28,11 @@ where
                     if let RequestError::Shutdown = self.session.run(&mut phys).await {
                         return Shutdown;
                     }
+                    // we wait here to prevent any kind of rapid retry scenario if the port opens and immediately fails
+                    tracing::warn!("waiting {:?} to reopen port", self.port_retry_delay);
+                    if let Err(Shutdown) = self.session.sleep_for(self.port_retry_delay).await {
+                        return Shutdown;
+                    }
                 }
                 Err(err) => {
                     tracing::warn!(

--- a/rodbus/src/serial/server.rs
+++ b/rodbus/src/serial/server.rs
@@ -22,6 +22,7 @@ where
         loop {
             match crate::serial::open(&self.port, self.settings) {
                 Ok(serial) => {
+                    tracing::info!("opened port");
                     // run an open port until shutdown or failure
                     let mut phys = PhysLayer::new_serial(serial);
                     if let RequestError::Shutdown = self.session.run(&mut phys).await {

--- a/rodbus/src/server/mod.rs
+++ b/rodbus/src/server/mod.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use tracing::Instrument;
 
@@ -105,24 +106,29 @@ pub fn spawn_rtu_server_task<T: RequestHandler>(
     handlers: ServerHandlerMap<T>,
     decode: DecodeLevel,
 ) -> Result<ServerHandle, std::io::Error> {
-    let serial = crate::serial::open(path, settings)?;
-
     let (tx, rx) = tokio::sync::mpsc::channel(SERVER_SETTING_CHANNEL_CAPACITY);
+    let session = crate::server::task::SessionTask::new(
+        handlers,
+        crate::server::task::AuthorizationType::None,
+        crate::common::frame::FrameWriter::rtu(),
+        crate::common::frame::FramedReader::rtu_request(),
+        rx,
+        decode,
+    );
 
-    let mut phys = crate::common::phys::PhysLayer::new_serial(serial);
+    let mut rtu = crate::serial::server::RtuServerTask {
+        port: path.to_string(),
+        port_retry_delay: Duration::from_secs(3), // TODO
+        settings,
+        session,
+    };
+
     let path = path.to_string();
+
     let task = async move {
-        crate::server::task::SessionTask::new(
-            handlers,
-            crate::server::task::AuthorizationType::None,
-            crate::common::frame::FrameWriter::rtu(),
-            crate::common::frame::FramedReader::rtu_request(),
-            rx,
-            decode,
-        )
-        .run(&mut phys)
-        .instrument(tracing::info_span!("Modbus-Server-RTU", "port" = ?path))
-        .await
+        rtu.run()
+            .instrument(tracing::info_span!("Modbus-Server-RTU", "port" = ?path))
+            .await
     };
 
     tokio::spawn(task);

--- a/rodbus/src/server/mod.rs
+++ b/rodbus/src/server/mod.rs
@@ -109,11 +109,10 @@ pub fn spawn_rtu_server_task<T: RequestHandler>(
 
     let (tx, rx) = tokio::sync::mpsc::channel(SERVER_SETTING_CHANNEL_CAPACITY);
 
-    let phys = crate::common::phys::PhysLayer::new_serial(serial);
+    let mut phys = crate::common::phys::PhysLayer::new_serial(serial);
     let path = path.to_string();
     let task = async move {
         crate::server::task::SessionTask::new(
-            phys,
             handlers,
             crate::server::task::AuthorizationType::None,
             crate::common::frame::FrameWriter::rtu(),
@@ -121,7 +120,7 @@ pub fn spawn_rtu_server_task<T: RequestHandler>(
             rx,
             decode,
         )
-        .run()
+        .run(&mut phys)
         .instrument(tracing::info_span!("Modbus-Server-RTU", "port" = ?path))
         .await
     };

--- a/rodbus/src/server/mod.rs
+++ b/rodbus/src/server/mod.rs
@@ -103,6 +103,7 @@ pub async fn spawn_tcp_server_task<T: RequestHandler>(
 pub fn spawn_rtu_server_task<T: RequestHandler>(
     path: &str,
     settings: crate::serial::SerialSettings,
+    port_retry_delay: Duration,
     handlers: ServerHandlerMap<T>,
     decode: DecodeLevel,
 ) -> Result<ServerHandle, std::io::Error> {
@@ -118,7 +119,7 @@ pub fn spawn_rtu_server_task<T: RequestHandler>(
 
     let mut rtu = crate::serial::server::RtuServerTask {
         port: path.to_string(),
-        port_retry_delay: Duration::from_secs(3), // TODO
+        port_retry_delay,
         settings,
         session,
     };

--- a/rodbus/src/tcp/server.rs
+++ b/rodbus/src/tcp/server.rs
@@ -239,9 +239,8 @@ async fn run_session<T: RequestHandler>(
         Err(err) => {
             tracing::warn!("error from {}: {}", addr, err);
         }
-        Ok((phys, auth)) => {
+        Ok((mut phys, auth)) => {
             let _ = crate::server::task::SessionTask::new(
-                phys,
                 handlers,
                 auth,
                 FrameWriter::tcp(),
@@ -249,7 +248,7 @@ async fn run_session<T: RequestHandler>(
                 commands,
                 decode,
             )
-            .run()
+            .run(&mut phys)
             .await;
         }
     }


### PR DESCRIPTION
The RTU server now opens the port on the Tokio task. It will retry at a configurable rate. If the port fails while running, it will retry to open the port after the delay.

This change was motivated by the fact that people use USB dongles that can be added/removed at will.