### PR TITLE
Serial retry strategy

### DIFF
--- a/ffi/bindings/c/client_example.c
+++ b/ffi/bindings/c/client_example.c
@@ -212,7 +212,7 @@ int run_rtu_channel(rodbus_runtime_t* runtime)
         "/dev/ttySIM0", // path
         rodbus_serial_port_settings_init(), // serial settings
         1, // max queued requests
-        1000, // retry delay (in ms)
+        rodbus_retry_strategy_init(),
         decode_level, // decode level
         get_port_listener(),
         &channel

--- a/ffi/bindings/c/client_example.cpp
+++ b/ffi/bindings/c/client_example.cpp
@@ -200,7 +200,7 @@ int run_rtu_channel(rodbus::Runtime& runtime)
         "/dev/ttySIM0",
         rodbus::SerialPortSettings(),
         1,
-        std::chrono::seconds(1),
+        rodbus::RetryStrategy(),
         rodbus::DecodeLevel::nothing(),
         std::make_unique<PrintingPortStateListener>()
     );

--- a/ffi/bindings/c/server_example.c
+++ b/ffi/bindings/c/server_example.c
@@ -219,7 +219,7 @@ int run_rtu_channel(rodbus_runtime_t* runtime)
     rodbus_server_t* server = NULL;
     rodbus_device_map_t* map = build_device_map();
     rodbus_decode_level_t decode_level = rodbus_decode_level_nothing();
-    rodbus_param_error_t err = rodbus_server_create_rtu(runtime, "/dev/ttySIM1", rodbus_serial_port_settings_init(), 3000, map, decode_level, &server);
+    rodbus_param_error_t err = rodbus_server_create_rtu(runtime, "/dev/ttySIM1", rodbus_serial_port_settings_init(), rodbus_retry_strategy_init(), map, decode_level, &server);
     rodbus_device_map_destroy(map);
 
     if (err) {

--- a/ffi/bindings/c/server_example.cpp
+++ b/ffi/bindings/c/server_example.cpp
@@ -223,7 +223,7 @@ int run_rtu_server(rodbus::Runtime& runtime)
     auto device_map = create_device_map();
 
     // ANCHOR: rtu_server_create
-    auto server = rodbus::Server::create_rtu(runtime, "/dev/ttySIM1", rodbus::SerialPortSettings(), std::chrono::seconds(3), device_map, rodbus::DecodeLevel::nothing());
+    auto server = rodbus::Server::create_rtu(runtime, "/dev/ttySIM1", rodbus::SerialPortSettings(), rodbus::RetryStrategy(), device_map, rodbus::DecodeLevel::nothing());
     // ANCHOR_END: rtu_server_create
 
     return run_server(server);

--- a/ffi/bindings/dotnet/examples/client/Program.cs
+++ b/ffi/bindings/dotnet/examples/client/Program.cs
@@ -111,7 +111,7 @@ namespace example
                 "/dev/ttySIM0", // path
                 new SerialPortSettings(), // serial settings
                 1, // max queued requests
-                TimeSpan.FromSeconds(1), // retry delay
+                new RetryStrategy(),
                 DecodeLevel.Nothing(),
                 new PortStateListener()
             );

--- a/ffi/bindings/dotnet/examples/server/Program.cs
+++ b/ffi/bindings/dotnet/examples/server/Program.cs
@@ -196,7 +196,7 @@ namespace example
         private static Server CreateRtuServer(Runtime runtime, DeviceMap map)
         {
             // ANCHOR: rtu_server_create            
-            var server = Server.CreateRtu(runtime, "/dev/ttySIM1", new SerialPortSettings(), TimeSpan.FromSeconds(3), map, DecodeLevel.Nothing());
+            var server = Server.CreateRtu(runtime, "/dev/ttySIM1", new SerialPortSettings(), new RetryStrategy(), map, DecodeLevel.Nothing());
             // ANCHOR_END: rtu_server_create
 
             return server;

--- a/ffi/bindings/java/examples/src/main/java/io/stepfunc/rodbus/examples/ClientExample.java
+++ b/ffi/bindings/java/examples/src/main/java/io/stepfunc/rodbus/examples/ClientExample.java
@@ -99,7 +99,7 @@ public class ClientExample {
                 "/dev/ttySIM0", // path
                 new SerialPortSettings(), // serial settings
                 ushort(1), // max queued requests
-                Duration.ofSeconds(1), // retry delay
+                new RetryStrategy(),
                 DecodeLevel.nothing(), // decode level
                 new PrintingPortStateListener()
         );

--- a/ffi/bindings/java/examples/src/main/java/io/stepfunc/rodbus/examples/ServerExample.java
+++ b/ffi/bindings/java/examples/src/main/java/io/stepfunc/rodbus/examples/ServerExample.java
@@ -169,7 +169,7 @@ public class ServerExample {
 
     private static Server createRtuServer(Runtime runtime, DeviceMap map) {
         // ANCHOR: rtu_server_create
-        Server server = Server.createRtu(runtime, "/dev/ttySIM1", new SerialPortSettings(), Duration.ofSeconds(3), map, DecodeLevel.nothing());
+        Server server = Server.createRtu(runtime, "/dev/ttySIM1", new SerialPortSettings(), new RetryStrategy(), map, DecodeLevel.nothing());
         // ANCHOR_END: rtu_server_create
 
         return server;

--- a/ffi/rodbus-ffi/src/client.rs
+++ b/ffi/rodbus-ffi/src/client.rs
@@ -2,7 +2,6 @@ use crate::ffi;
 use rodbus::client::{ClientState, HostAddr, Listener, WriteMultiple};
 use rodbus::{AddressRange, MaybeAsync};
 use std::net::IpAddr;
-use std::time::Duration;
 
 pub struct ClientChannel {
     pub(crate) inner: rodbus::client::Channel,
@@ -56,7 +55,7 @@ pub(crate) unsafe fn client_channel_create_rtu(
     _path: &std::ffi::CStr,
     _serial_params: ffi::SerialPortSettings,
     _max_queued_requests: u16,
-    _open_retry_delay: Duration,
+    _retry_strategy: ffi::RetryStrategy,
     _decode_level: ffi::DecodeLevel,
     _listener: ffi::PortStateListener,
 ) -> Result<*mut crate::ClientChannel, ffi::ParamError> {
@@ -69,7 +68,7 @@ pub(crate) unsafe fn client_channel_create_rtu(
     path: &std::ffi::CStr,
     serial_params: ffi::SerialPortSettings,
     max_queued_requests: u16,
-    open_retry_delay: Duration,
+    retry_strategy: ffi::RetryStrategy,
     decode_level: ffi::DecodeLevel,
     listener: ffi::PortStateListener,
 ) -> Result<*mut crate::ClientChannel, ffi::ParamError> {
@@ -82,7 +81,7 @@ pub(crate) unsafe fn client_channel_create_rtu(
         &path.to_string_lossy(),
         serial_params.into(),
         max_queued_requests as usize,
-        open_retry_delay,
+        retry_strategy.into(),
         decode_level.into(),
         Some(listener.into()),
     );

--- a/ffi/rodbus-ffi/src/helpers/conversions.rs
+++ b/ffi/rodbus-ffi/src/helpers/conversions.rs
@@ -1,4 +1,4 @@
-use rodbus::client::ReconnectStrategy;
+use rodbus::client::RetryStrategy;
 use rodbus::server::Authorization;
 use rodbus::AddressRange;
 use rodbus::Shutdown;
@@ -150,9 +150,9 @@ impl From<ffi::CertificateMode> for rodbus::client::CertificateMode {
     }
 }
 
-impl From<ffi::RetryStrategy> for Box<dyn ReconnectStrategy + Send> {
+impl From<ffi::RetryStrategy> for Box<dyn RetryStrategy> {
     fn from(from: ffi::RetryStrategy) -> Self {
-        rodbus::client::doubling_reconnect_strategy(from.min_delay(), from.max_delay())
+        rodbus::doubling_retry_strategy(from.min_delay(), from.max_delay())
     }
 }
 

--- a/ffi/rodbus-ffi/src/server.rs
+++ b/ffi/rodbus-ffi/src/server.rs
@@ -318,7 +318,7 @@ pub(crate) unsafe fn server_create_rtu(
     _runtime: *mut crate::Runtime,
     _path: &std::ffi::CStr,
     _serial_params: ffi::SerialPortSettings,
-    _port_retry_delay: std::time::Duration,
+    _port_retry_delay: ffi::RetryStrategy,
     _endpoints: *mut crate::DeviceMap,
     _decode_level: ffi::DecodeLevel,
 ) -> Result<*mut crate::Server, ffi::ParamError> {
@@ -330,7 +330,7 @@ pub(crate) unsafe fn server_create_rtu(
     runtime: *mut crate::Runtime,
     path: &std::ffi::CStr,
     serial_params: ffi::SerialPortSettings,
-    port_retry_delay: std::time::Duration,
+    retry: ffi::RetryStrategy,
     endpoints: *mut crate::DeviceMap,
     decode_level: ffi::DecodeLevel,
 ) -> Result<*mut crate::Server, ffi::ParamError> {
@@ -344,7 +344,7 @@ pub(crate) unsafe fn server_create_rtu(
     let handle = rodbus::server::spawn_rtu_server_task(
         &path.to_string_lossy(),
         serial_params.into(),
-        port_retry_delay,
+        retry.into(),
         handler_map.clone(),
         decode_level.into(),
     )

--- a/ffi/rodbus-schema/src/client.rs
+++ b/ffi/rodbus-schema/src/client.rs
@@ -71,9 +71,9 @@ pub(crate) fn build(lib: &mut LibraryBuilder, common: &CommonDefinitions) -> Bac
             "Maximum number of requests to queue before failing the next request",
         )?
         .param(
-            "open_retry_delay",
-            DurationType::Milliseconds,
-            "Delay between attempts to open the serial port",
+            "retry_strategy",
+            retry_strategy.clone(),
+            "Strategy which controls how long to wait between attempts to open the serial port after failures",
         )?
         .param(
             "decode_level",

--- a/ffi/rodbus-schema/src/client.rs
+++ b/ffi/rodbus-schema/src/client.rs
@@ -5,7 +5,6 @@ use crate::common::CommonDefinitions;
 pub(crate) fn build(lib: &mut LibraryBuilder, common: &CommonDefinitions) -> BackTraced<()> {
     let channel = lib.declare_class("client_channel")?;
 
-    let retry_strategy = build_retry_strategy(lib)?;
     let tls_client_config = build_tls_client_config(lib, common)?;
     let client_state_listener = define_tcp_client_state_listener(lib)?;
     let port_state_listener = define_port_state_listener(lib)?;
@@ -30,7 +29,7 @@ pub(crate) fn build(lib: &mut LibraryBuilder, common: &CommonDefinitions) -> Bac
         )?
         .param(
             "retry_strategy",
-            retry_strategy.clone(),
+            common.retry_strategy.clone(),
             "Reconnection timing strategy",
         )?
         .param(
@@ -72,7 +71,7 @@ pub(crate) fn build(lib: &mut LibraryBuilder, common: &CommonDefinitions) -> Bac
         )?
         .param(
             "retry_strategy",
-            retry_strategy.clone(),
+            common.retry_strategy.clone(),
             "Strategy which controls how long to wait between attempts to open the serial port after failures",
         )?
         .param(
@@ -110,7 +109,7 @@ pub(crate) fn build(lib: &mut LibraryBuilder, common: &CommonDefinitions) -> Bac
         )?
         .param(
             "retry_strategy",
-            retry_strategy,
+            common.retry_strategy.clone(),
             "Reconnection timing strategy",
         )?
         .param("tls_config", tls_client_config, "TLS client configuration")?
@@ -458,40 +457,6 @@ fn build_write_callback(
     )?;
 
     Ok(future)
-}
-
-fn build_retry_strategy(lib: &mut LibraryBuilder) -> BackTraced<UniversalStructHandle> {
-    let min_delay_field = Name::create("min_delay")?;
-    let max_delay_field = Name::create("max_delay")?;
-
-    let retry_strategy = lib.declare_universal_struct("retry_strategy")?;
-    let retry_strategy = lib
-        .define_universal_struct(retry_strategy)?
-        .add(
-            &min_delay_field,
-            DurationType::Milliseconds,
-            "Minimum delay between two retries",
-        )?
-        .add(
-            &max_delay_field,
-            DurationType::Milliseconds,
-            "Maximum delay between two retries",
-        )?
-        .doc(doc("Retry strategy configuration.").details(
-            "The strategy uses an exponential back-off with a minimum and maximum value.",
-        ))?
-        .end_fields()?
-        .begin_initializer(
-            "init",
-            InitializerType::Normal,
-            "Initialize a retry strategy to defaults",
-        )?
-        .default(&min_delay_field, std::time::Duration::from_secs(1))?
-        .default(&max_delay_field, std::time::Duration::from_secs(10))?
-        .end_initializer()?
-        .build()?;
-
-    Ok(retry_strategy)
 }
 
 fn build_tls_client_config(

--- a/ffi/rodbus-schema/src/server.rs
+++ b/ffi/rodbus-schema/src/server.rs
@@ -85,9 +85,9 @@ pub(crate) fn build_server(
             "Serial port settings",
         )?
         .param(
-            "port_retry_delay",
-            DurationType::Milliseconds,
-            "How long to wait before re-opening the serial port",
+            "retry",
+            common.retry_strategy.clone(),
+            "Parameters that control How long to wait before re-opening the serial port",
         )?
         .param(
             "endpoints",

--- a/rodbus-client/src/main.rs
+++ b/rodbus-client/src/main.rs
@@ -71,7 +71,7 @@ async fn run() -> Result<(), Error> {
     let mut channel = spawn_tcp_client_task(
         HostAddr::ip(args.address.ip(), args.address.port()),
         1,
-        default_reconnect_strategy(),
+        default_retry_strategy(),
         AppDecodeLevel::DataValues.into(),
         None,
     );

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -80,7 +80,7 @@ async fn run_rtu() -> Result<(), Box<dyn std::error::Error>> {
         "/dev/ttySIM0",                    // path
         rodbus::SerialSettings::default(), // serial settings
         1,                                 // max queued requests
-        Duration::from_secs(1),            // retry delay
+        default_reconnect_strategy(),      // retry delays
         DecodeLevel::new(
             AppDecodeLevel::DataValues,
             FrameDecodeLevel::Payload,

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -64,7 +64,7 @@ async fn run_tcp() -> Result<(), Box<dyn std::error::Error>> {
     let channel = spawn_tcp_client_task(
         HostAddr::ip(IpAddr::V4(Ipv4Addr::LOCALHOST), 502),
         1,
-        default_reconnect_strategy(),
+        default_retry_strategy(),
         DecodeLevel::default(),
         Some(Box::new(LoggingListener)),
     );
@@ -80,7 +80,7 @@ async fn run_rtu() -> Result<(), Box<dyn std::error::Error>> {
         "/dev/ttySIM0",                    // path
         rodbus::SerialSettings::default(), // serial settings
         1,                                 // max queued requests
-        default_reconnect_strategy(),      // retry delays
+        default_retry_strategy(),          // retry delays
         DecodeLevel::new(
             AppDecodeLevel::DataValues,
             FrameDecodeLevel::Payload,
@@ -99,7 +99,7 @@ async fn run_tls(tls_config: TlsClientConfig) -> Result<(), Box<dyn std::error::
     let channel = spawn_tls_client_task(
         HostAddr::ip(IpAddr::V4(Ipv4Addr::LOCALHOST), 802),
         1,
-        default_reconnect_strategy(),
+        default_retry_strategy(),
         tls_config,
         DecodeLevel::new(
             AppDecodeLevel::DataValues,

--- a/rodbus/examples/perf.rs
+++ b/rodbus/examples/perf.rs
@@ -62,7 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let channel = spawn_tcp_client_task(
             addr.into(),
             10,
-            default_reconnect_strategy(),
+            default_retry_strategy(),
             DecodeLevel::new(
                 AppDecodeLevel::Nothing,
                 FrameDecodeLevel::Nothing,

--- a/rodbus/examples/server.rs
+++ b/rodbus/examples/server.rs
@@ -1,5 +1,4 @@
 use std::process::exit;
-use std::time::Duration;
 
 use tokio_stream::StreamExt;
 use tokio_util::codec::{FramedRead, LinesCodec};
@@ -188,7 +187,7 @@ async fn run_rtu() -> Result<(), Box<dyn std::error::Error>> {
     let server = rodbus::server::spawn_rtu_server_task(
         "/dev/ttySIM1",
         rodbus::SerialSettings::default(),
-        Duration::from_secs(3),
+        default_retry_strategy(),
         map,
         DecodeLevel::new(
             AppDecodeLevel::DataValues,

--- a/rodbus/src/client/channel.rs
+++ b/rodbus/src/client/channel.rs
@@ -103,7 +103,7 @@ impl Channel {
         path: &str,
         serial_settings: crate::serial::SerialSettings,
         max_queued_requests: usize,
-        retry_delay: Duration,
+        retry: Box<dyn ReconnectStrategy + Send>,
         decode: DecodeLevel,
         listener: Option<Box<dyn crate::client::Listener<crate::client::PortState>>>,
     ) -> Self {
@@ -111,7 +111,7 @@ impl Channel {
             path,
             serial_settings,
             max_queued_requests,
-            retry_delay,
+            retry,
             decode,
             listener,
         );
@@ -124,7 +124,7 @@ impl Channel {
         path: &str,
         serial_settings: crate::serial::SerialSettings,
         max_queued_requests: usize,
-        retry_delay: Duration,
+        retry: Box<dyn ReconnectStrategy + Send>,
         decode: DecodeLevel,
         listener: Option<Box<dyn crate::client::Listener<crate::client::PortState>>>,
     ) -> (Self, impl std::future::Future<Output = ()>) {
@@ -137,7 +137,7 @@ impl Channel {
                 &path,
                 serial_settings,
                 rx,
-                retry_delay,
+                retry,
                 decode,
                 listener.unwrap_or_else(|| crate::client::NullListener::create()),
             )

--- a/rodbus/src/client/channel.rs
+++ b/rodbus/src/client/channel.rs
@@ -7,7 +7,7 @@ use crate::client::requests::write_multiple::{MultipleWriteRequest, WriteMultipl
 use crate::client::requests::write_single::SingleWrite;
 use crate::error::*;
 use crate::types::{AddressRange, BitIterator, Indexed, RegisterIterator, UnitId};
-use crate::{DecodeLevel, RetryStrategy};
+use crate::DecodeLevel;
 
 /// Async channel used to make requests
 #[derive(Debug, Clone)]
@@ -40,7 +40,7 @@ impl Channel {
         path: &str,
         serial_settings: crate::serial::SerialSettings,
         max_queued_requests: usize,
-        retry: Box<dyn RetryStrategy>,
+        retry: Box<dyn crate::retry::RetryStrategy>,
         decode: DecodeLevel,
         listener: Option<Box<dyn crate::client::Listener<crate::client::PortState>>>,
     ) -> Self {
@@ -61,7 +61,7 @@ impl Channel {
         path: &str,
         serial_settings: crate::serial::SerialSettings,
         max_queued_requests: usize,
-        retry: Box<dyn RetryStrategy>,
+        retry: Box<dyn crate::retry::RetryStrategy>,
         decode: DecodeLevel,
         listener: Option<Box<dyn crate::client::Listener<crate::client::PortState>>>,
     ) -> (Self, impl std::future::Future<Output = ()>) {

--- a/rodbus/src/client/mod.rs
+++ b/rodbus/src/client/mod.rs
@@ -107,7 +107,7 @@ pub fn spawn_tcp_client_task(
 /// * `path` - Path to the serial device. Generally `/dev/tty0` on Linux and `COM1` on Windows.
 /// * `serial_settings` = Serial port settings
 /// * `max_queued_requests` - The maximum size of the request queue
-/// * `retry` - Delay between attempts to open the serial port
+/// * `retry` - A boxed trait object that controls when opening the serial port is retried on failure
 /// * `decode` - Decode log level
 ///
 /// `WARNING`: This function must be called from with the context of the Tokio runtime or it will panic.
@@ -116,7 +116,7 @@ pub fn spawn_rtu_client_task(
     path: &str,
     serial_settings: crate::serial::SerialSettings,
     max_queued_requests: usize,
-    retry_delay: std::time::Duration,
+    retry: Box<dyn ReconnectStrategy + Send>,
     decode: DecodeLevel,
     listener: Option<Box<dyn Listener<PortState>>>,
 ) -> Channel {
@@ -124,7 +124,7 @@ pub fn spawn_rtu_client_task(
         path,
         serial_settings,
         max_queued_requests,
-        retry_delay,
+        retry,
         decode,
         listener,
     )

--- a/rodbus/src/client/mod.rs
+++ b/rodbus/src/client/mod.rs
@@ -81,7 +81,7 @@ impl HostAddr {
 /// * `max_queued_requests` - The maximum size of the request queue
 /// * `retry` - A boxed trait object that controls when the connection is retried on failure
 /// * `decode` - Decode log level
-/// * `listener` - Callback for the TCP connection state
+/// * `listener` - Optional callback to monitor the TCP connection state
 ///
 /// `WARNING`: This function must be called from with the context of the Tokio runtime or it will panic.
 pub fn spawn_tcp_client_task(
@@ -112,6 +112,7 @@ pub fn spawn_tcp_client_task(
 /// * `max_queued_requests` - The maximum size of the request queue
 /// * `retry` - A boxed trait object that controls when opening the serial port is retried on failure
 /// * `decode` - Decode log level
+/// * `listener` - Optional callback to monitor the state of the serial port
 ///
 /// `WARNING`: This function must be called from with the context of the Tokio runtime or it will panic.
 #[cfg(feature = "serial")]
@@ -144,7 +145,7 @@ pub fn spawn_rtu_client_task(
 /// * `retry` - A boxed trait object that controls when the connection is retried on failure
 /// * `tls_config` - TLS configuration
 /// * `decode` - Decode log level
-/// * `listener` - Callback for the TCP connection state
+/// * `listener` - Optional callback to monitor the TLS connection state
 ///
 /// `WARNING`: This function must be called from with the context of the Tokio runtime or it will panic.
 #[cfg(feature = "tls")]

--- a/rodbus/src/client/mod.rs
+++ b/rodbus/src/client/mod.rs
@@ -9,10 +9,10 @@ pub(crate) mod message;
 pub(crate) mod requests;
 pub(crate) mod task;
 
-pub use crate::client::channel::strategy::*;
 pub use crate::client::channel::*;
 pub use crate::client::listener::*;
 pub use crate::client::requests::write_multiple::WriteMultiple;
+pub use crate::retry::*;
 
 #[cfg(feature = "tls")]
 pub use crate::tcp::tls::client::TlsClientConfig;
@@ -75,7 +75,7 @@ impl HostAddr {
 /// Spawns a channel task onto the runtime that maintains a TCP connection and processes
 /// requests. The task completes when the returned channel handle is dropped.
 ///
-/// The channel uses the provided [`ReconnectStrategy`] to pause between failed connection attempts
+/// The channel uses the provided [`RetryStrategy`] to pause between failed connection attempts
 ///
 /// * `host` - Address/port of the remote server. Can be a IP address or name on which to perform DNS resolution.
 /// * `max_queued_requests` - The maximum size of the request queue
@@ -87,7 +87,7 @@ impl HostAddr {
 pub fn spawn_tcp_client_task(
     host: HostAddr,
     max_queued_requests: usize,
-    retry: Box<dyn ReconnectStrategy + Send>,
+    retry: Box<dyn RetryStrategy>,
     decode: DecodeLevel,
     listener: Option<Box<dyn Listener<ClientState>>>,
 ) -> Channel {
@@ -104,6 +104,9 @@ pub fn spawn_tcp_client_task(
 /// requests. The task completes when the returned channel handle
 /// is dropped.
 ///
+/// The channel uses the provided [`RetryStrategy`] to pause between failed attempts to open the
+/// serial port or after the serial port fails.
+///
 /// * `path` - Path to the serial device. Generally `/dev/tty0` on Linux and `COM1` on Windows.
 /// * `serial_settings` = Serial port settings
 /// * `max_queued_requests` - The maximum size of the request queue
@@ -116,7 +119,7 @@ pub fn spawn_rtu_client_task(
     path: &str,
     serial_settings: crate::serial::SerialSettings,
     max_queued_requests: usize,
-    retry: Box<dyn ReconnectStrategy + Send>,
+    retry: Box<dyn RetryStrategy>,
     decode: DecodeLevel,
     listener: Option<Box<dyn Listener<PortState>>>,
 ) -> Channel {
@@ -134,7 +137,7 @@ pub fn spawn_rtu_client_task(
 /// requests. The task completes when the returned channel handle
 /// is dropped.
 ///
-/// The channel uses the provided [`ReconnectStrategy`] to pause between failed connection attempts
+/// The channel uses the provided [`RetryStrategy`] to pause between failed connection attempts
 ///
 /// * `host` - Address/port of the remote server. Can be a IP address or name on which to perform DNS resolution.
 /// * `max_queued_requests` - The maximum size of the request queue
@@ -148,7 +151,7 @@ pub fn spawn_rtu_client_task(
 pub fn spawn_tls_client_task(
     host: HostAddr,
     max_queued_requests: usize,
-    retry: Box<dyn ReconnectStrategy + Send>,
+    retry: Box<dyn RetryStrategy>,
     tls_config: TlsClientConfig,
     decode: DecodeLevel,
     listener: Option<Box<dyn Listener<ClientState>>>,

--- a/rodbus/src/lib.rs
+++ b/rodbus/src/lib.rs
@@ -56,7 +56,7 @@
 //!    let mut channel = spawn_tcp_client_task(
 //!        HostAddr::ip("127.0.0.1".parse()?, 502),
 //!        10,
-//!        default_reconnect_strategy(),
+//!        default_retry_strategy(),
 //!        DecodeLevel::default(),
 //!        None
 //!    );
@@ -211,6 +211,7 @@ pub(crate) mod decode;
 pub(crate) mod error;
 pub(crate) mod exception;
 pub(crate) mod maybe_async;
+pub(crate) mod retry;
 #[cfg(feature = "serial")]
 mod serial;
 pub(crate) mod types;
@@ -220,6 +221,7 @@ pub use crate::decode::*;
 pub use crate::error::*;
 pub use crate::exception::*;
 pub use crate::maybe_async::*;
+pub use crate::retry::*;
 #[cfg(feature = "serial")]
 pub use crate::serial::*;
 pub use crate::types::*;

--- a/rodbus/src/retry.rs
+++ b/rodbus/src/retry.rs
@@ -1,0 +1,53 @@
+use std::time::Duration;
+
+/// Trait that controls how the channel retries failed connect (TCP/TLS) or open (serial) attempts
+pub trait RetryStrategy: Send {
+    /// Reset internal state. Called when a connection is successful or a port is opened
+    fn reset(&mut self);
+    /// Return the next delay before making another connection/open attempt
+    fn after_failed_connect(&mut self) -> Duration;
+    /// Return the delay to wait after a disconnect before attempting to reconnect/open
+    fn after_disconnect(&mut self) -> Duration;
+}
+
+/// Return the default [`RetryStrategy`]
+pub fn default_retry_strategy() -> Box<dyn RetryStrategy> {
+    doubling_retry_strategy(Duration::from_millis(100), Duration::from_secs(5))
+}
+
+/// Return a [`RetryStrategy`] that doubles on failure up to a maximum value
+pub fn doubling_retry_strategy(min: Duration, max: Duration) -> Box<dyn RetryStrategy> {
+    Doubling::create(min, max)
+}
+
+struct Doubling {
+    min: Duration,
+    max: Duration,
+    current: Duration,
+}
+
+impl Doubling {
+    pub(crate) fn create(min: Duration, max: Duration) -> Box<dyn RetryStrategy> {
+        Box::new(Doubling {
+            min,
+            max,
+            current: min,
+        })
+    }
+}
+
+impl RetryStrategy for Doubling {
+    fn reset(&mut self) {
+        self.current = self.min;
+    }
+
+    fn after_failed_connect(&mut self) -> Duration {
+        let ret = self.current;
+        self.current = std::cmp::min(2 * self.current, self.max);
+        ret
+    }
+
+    fn after_disconnect(&mut self) -> Duration {
+        self.min
+    }
+}

--- a/rodbus/src/retry.rs
+++ b/rodbus/src/retry.rs
@@ -12,7 +12,7 @@ pub trait RetryStrategy: Send {
 
 /// Return the default [`RetryStrategy`]
 pub fn default_retry_strategy() -> Box<dyn RetryStrategy> {
-    doubling_retry_strategy(Duration::from_millis(100), Duration::from_secs(5))
+    doubling_retry_strategy(Duration::from_millis(1000), Duration::from_secs(60000))
 }
 
 /// Return a [`RetryStrategy`] that doubles on failure up to a maximum value

--- a/rodbus/src/serial/client.rs
+++ b/rodbus/src/serial/client.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use crate::common::phys::PhysLayer;
 use crate::decode::DecodeLevel;
 use crate::serial::SerialSettings;
@@ -7,14 +5,14 @@ use tokio::sync::mpsc::Receiver;
 
 use crate::client::message::Command;
 use crate::client::task::{ClientLoop, SessionError, StateChange};
-use crate::client::{Listener, PortState};
+use crate::client::{Listener, PortState, ReconnectStrategy};
 use crate::common::frame::{FrameWriter, FramedReader};
 use crate::error::Shutdown;
 
 pub(crate) struct SerialChannelTask {
     path: String,
     serial_settings: SerialSettings,
-    retry_delay: Duration,
+    retry: Box<dyn ReconnectStrategy + Send>,
     client_loop: ClientLoop,
     listener: Box<dyn Listener<PortState>>,
 }
@@ -24,14 +22,14 @@ impl SerialChannelTask {
         path: &str,
         serial_settings: SerialSettings,
         rx: Receiver<Command>,
-        retry_delay: Duration,
+        retry: Box<dyn ReconnectStrategy + Send>,
         decode: DecodeLevel,
         listener: Box<dyn Listener<PortState>>,
     ) -> Self {
         Self {
             path: path.to_string(),
             serial_settings,
-            retry_delay,
+            retry,
             client_loop: ClientLoop::new(
                 rx,
                 FrameWriter::rtu(),
@@ -69,27 +67,27 @@ impl SerialChannelTask {
     pub(crate) async fn try_open_and_run(&mut self) -> Result<(), StateChange> {
         match crate::serial::open(self.path.as_str(), self.serial_settings) {
             Err(err) => {
-                self.listener
-                    .update(PortState::Wait(self.retry_delay))
-                    .get()
-                    .await;
-                tracing::warn!(
-                    "{} - waiting {} ms to re-open port",
-                    err,
-                    self.retry_delay.as_millis()
-                );
-                self.client_loop.fail_requests_for(self.retry_delay).await
+                let delay = self.retry.after_failed_connect();
+                self.listener.update(PortState::Wait(delay)).get().await;
+                tracing::warn!("{} - waiting {} ms to re-open port", err, delay.as_millis());
+                self.client_loop.fail_requests_for(delay).await
             }
             Ok(serial) => {
+                self.retry.reset();
                 self.listener.update(PortState::Open).get().await;
                 let mut phys = PhysLayer::new_serial(serial);
                 tracing::info!("serial port open");
                 match self.client_loop.run(&mut phys).await {
                     // the mpsc was closed, end the task
                     SessionError::Shutdown => Err(StateChange::Shutdown),
-                    // re-establish the connection or wait to be enabled
-                    SessionError::Disabled | SessionError::IoError(_) | SessionError::BadFrame => {
-                        Ok(())
+                    // don't wait, we're disabled
+                    SessionError::Disabled => Ok(()),
+                    // wait before retrying
+                    SessionError::IoError(_) | SessionError::BadFrame => {
+                        let delay = self.retry.after_disconnect();
+                        self.listener.update(PortState::Wait(delay)).get().await;
+                        tracing::warn!("waiting {} ms to re-open port", delay.as_millis());
+                        self.client_loop.fail_requests_for(delay).await
                     }
                 }
             }

--- a/rodbus/src/serial/client.rs
+++ b/rodbus/src/serial/client.rs
@@ -5,14 +5,14 @@ use tokio::sync::mpsc::Receiver;
 
 use crate::client::message::Command;
 use crate::client::task::{ClientLoop, SessionError, StateChange};
-use crate::client::{Listener, PortState, ReconnectStrategy};
+use crate::client::{Listener, PortState, RetryStrategy};
 use crate::common::frame::{FrameWriter, FramedReader};
 use crate::error::Shutdown;
 
 pub(crate) struct SerialChannelTask {
     path: String,
     serial_settings: SerialSettings,
-    retry: Box<dyn ReconnectStrategy + Send>,
+    retry: Box<dyn RetryStrategy>,
     client_loop: ClientLoop,
     listener: Box<dyn Listener<PortState>>,
 }
@@ -22,7 +22,7 @@ impl SerialChannelTask {
         path: &str,
         serial_settings: SerialSettings,
         rx: Receiver<Command>,
-        retry: Box<dyn ReconnectStrategy + Send>,
+        retry: Box<dyn RetryStrategy>,
         decode: DecodeLevel,
         listener: Box<dyn Listener<PortState>>,
     ) -> Self {

--- a/rodbus/src/serial/server.rs
+++ b/rodbus/src/serial/server.rs
@@ -1,15 +1,14 @@
 use crate::common::phys::PhysLayer;
 use crate::server::task::SessionTask;
 use crate::server::RequestHandler;
-use crate::{RequestError, SerialSettings, Shutdown};
-use std::time::Duration;
+use crate::{RequestError, RetryStrategy, SerialSettings, Shutdown};
 
 pub(crate) struct RtuServerTask<T>
 where
     T: RequestHandler,
 {
     pub(crate) port: String,
-    pub(crate) port_retry_delay: Duration,
+    pub(crate) retry: Box<dyn RetryStrategy>,
     pub(crate) settings: SerialSettings,
     pub(crate) session: SessionTask<T>,
 }
@@ -22,6 +21,7 @@ where
         loop {
             match crate::serial::open(&self.port, self.settings) {
                 Ok(serial) => {
+                    self.retry.reset();
                     tracing::info!("opened port");
                     // run an open port until shutdown or failure
                     let mut phys = PhysLayer::new_serial(serial);
@@ -29,18 +29,20 @@ where
                         return Shutdown;
                     }
                     // we wait here to prevent any kind of rapid retry scenario if the port opens and immediately fails
-                    tracing::warn!("waiting {:?} to reopen port", self.port_retry_delay);
-                    if let Err(Shutdown) = self.session.sleep_for(self.port_retry_delay).await {
+                    let delay = self.retry.after_disconnect();
+                    tracing::warn!("waiting {:?} to reopen port", delay);
+                    if let Err(Shutdown) = self.session.sleep_for(delay).await {
                         return Shutdown;
                     }
                 }
                 Err(err) => {
+                    let delay = self.retry.after_failed_connect();
                     tracing::warn!(
                         "unable to open serial port, retrying in {:?} - error: {}",
-                        self.port_retry_delay,
+                        delay,
                         err
                     );
-                    if let Err(Shutdown) = self.session.sleep_for(self.port_retry_delay).await {
+                    if let Err(Shutdown) = self.session.sleep_for(delay).await {
                         return Shutdown;
                     }
                 }

--- a/rodbus/src/server/mod.rs
+++ b/rodbus/src/server/mod.rs
@@ -19,7 +19,6 @@ pub(crate) const SERVER_SETTING_CHANNEL_CAPACITY: usize = 8;
 
 use crate::error::Shutdown;
 
-use crate::RetryStrategy;
 pub use address_filter::*;
 pub use handler::*;
 pub use types::*;
@@ -106,7 +105,7 @@ pub async fn spawn_tcp_server_task<T: RequestHandler>(
 pub fn spawn_rtu_server_task<T: RequestHandler>(
     path: &str,
     settings: crate::serial::SerialSettings,
-    retry: Box<dyn RetryStrategy>,
+    retry: Box<dyn crate::retry::RetryStrategy>,
     handlers: ServerHandlerMap<T>,
     decode: DecodeLevel,
 ) -> Result<ServerHandle, std::io::Error> {

--- a/rodbus/src/tcp/client.rs
+++ b/rodbus/src/tcp/client.rs
@@ -4,11 +4,11 @@ use crate::client::{Channel, ClientState, HostAddr, Listener};
 use crate::common::phys::PhysLayer;
 use crate::decode::DecodeLevel;
 
-use crate::client::channel::ReconnectStrategy;
 use crate::client::message::Command;
 use crate::client::task::{ClientLoop, SessionError, StateChange};
 use crate::common::frame::{FrameWriter, FramedReader};
 use crate::error::Shutdown;
+use crate::retry::RetryStrategy;
 
 use tokio::net::TcpStream;
 use tokio::sync::mpsc::Receiver;
@@ -16,7 +16,7 @@ use tokio::sync::mpsc::Receiver;
 pub(crate) fn spawn_tcp_channel(
     host: HostAddr,
     max_queued_requests: usize,
-    connect_retry: Box<dyn ReconnectStrategy + Send>,
+    connect_retry: Box<dyn RetryStrategy>,
     decode: DecodeLevel,
     listener: Box<dyn Listener<ClientState>>,
 ) -> Channel {
@@ -29,7 +29,7 @@ pub(crate) fn spawn_tcp_channel(
 pub(crate) fn create_tcp_channel(
     host: HostAddr,
     max_queued_requests: usize,
-    connect_retry: Box<dyn ReconnectStrategy + Send>,
+    connect_retry: Box<dyn RetryStrategy>,
     decode: DecodeLevel,
     listener: Box<dyn Listener<ClientState>>,
 ) -> (Channel, impl std::future::Future<Output = ()>) {
@@ -72,7 +72,7 @@ impl TcpTaskConnectionHandler {
 
 pub(crate) struct TcpChannelTask {
     host: HostAddr,
-    connect_retry: Box<dyn ReconnectStrategy + Send>,
+    connect_retry: Box<dyn RetryStrategy>,
     connection_handler: TcpTaskConnectionHandler,
     client_loop: ClientLoop,
     listener: Box<dyn Listener<ClientState>>,
@@ -83,7 +83,7 @@ impl TcpChannelTask {
         host: HostAddr,
         rx: Receiver<Command>,
         connection_handler: TcpTaskConnectionHandler,
-        connect_retry: Box<dyn ReconnectStrategy + Send>,
+        connect_retry: Box<dyn RetryStrategy>,
         decode: DecodeLevel,
         listener: Box<dyn Listener<ClientState>>,
     ) -> Self {

--- a/rodbus/src/tcp/tls/client.rs
+++ b/rodbus/src/tcp/tls/client.rs
@@ -7,7 +7,7 @@ use tokio::net::TcpStream;
 use tokio_rustls::{rustls, webpki};
 use tracing::Instrument;
 
-use crate::client::{Channel, ClientState, HostAddr, Listener, ReconnectStrategy};
+use crate::client::{Channel, ClientState, HostAddr, Listener, RetryStrategy};
 use crate::common::phys::PhysLayer;
 use crate::tcp::client::{TcpChannelTask, TcpTaskConnectionHandler};
 use crate::tcp::tls::{load_certs, load_private_key, CertificateMode, MinTlsVersion, TlsError};
@@ -23,7 +23,7 @@ pub struct TlsClientConfig {
 pub(crate) fn spawn_tls_channel(
     host: HostAddr,
     max_queued_requests: usize,
-    connect_retry: Box<dyn ReconnectStrategy + Send>,
+    connect_retry: Box<dyn RetryStrategy>,
     tls_config: TlsClientConfig,
     decode: DecodeLevel,
     listener: Box<dyn Listener<ClientState>>,
@@ -43,7 +43,7 @@ pub(crate) fn spawn_tls_channel(
 pub(crate) fn create_tls_channel(
     host: HostAddr,
     max_queued_requests: usize,
-    connect_retry: Box<dyn ReconnectStrategy + Send>,
+    connect_retry: Box<dyn RetryStrategy>,
     tls_config: TlsClientConfig,
     decode: DecodeLevel,
     listener: Box<dyn Listener<ClientState>>,

--- a/rodbus/tests/integration_test.rs
+++ b/rodbus/tests/integration_test.rs
@@ -113,7 +113,7 @@ async fn test_requests_and_responses() {
     let mut channel = spawn_tcp_client_task(
         HostAddr::ip(addr.ip(), addr.port()),
         10,
-        default_reconnect_strategy(),
+        default_retry_strategy(),
         DecodeLevel::default(),
         None,
     );


### PR DESCRIPTION
* Rename `ReconnectStrategy` to `RetryStrategy` in Rust
* Use a `RetryStrategy` instead of a single timeout for RTU mode client and server