### PR TITLE
enable TCP_NODELAY for client and server sockets

### DIFF
--- a/rodbus/src/tcp/client.rs
+++ b/rodbus/src/tcp/client.rs
@@ -141,6 +141,9 @@ impl TcpChannelTask {
                 if let Ok(addr) = socket.peer_addr() {
                     tracing::info!("connected to: {}", addr);
                 }
+                if let Err(err) = socket.set_nodelay(true) {
+                    tracing::warn!("unable to enable TCP_NODELAY: {}", err);
+                }
                 match self.connection_handler.handle(socket, &self.host).await {
                     Err(err) => {
                         let delay = self.connect_retry.after_failed_connect();

--- a/rodbus/src/tcp/server.rs
+++ b/rodbus/src/tcp/server.rs
@@ -176,6 +176,9 @@ where
                         }
                         Ok((socket, addr)) => {
                             if self.filter.matches(addr.ip()) {
+                                if let Err(err) = socket.set_nodelay(true) {
+                                    tracing::warn!("unable to enable TCP_NODELAY: {}", err);
+                                }
                                 self.handle(socket, addr).await
                             } else {
                                 tracing::warn!("IP address {:?} does not match filter {:?}, closing connection", addr.ip(), self.filter);


### PR DESCRIPTION
Modbus always writes full MBAPs, Nagle's algorithm should always be disabled to reduce possibly latency.