### PR TITLE
Enable full LTO for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ members = [
   "ffi/rodbus-ffi-java",
   "ffi/rodbus-schema",
 ]
+
+[profile.release]
+lto=true


### PR DESCRIPTION
There doesn't appear to be any downsides other than build time. Resulting library and perf binary are smaller and performance tests show a speedup on Windows/Linux.