### PR TITLE
Ability to disable server name checking in TLS client

### DIFF
--- a/ffi/rodbus-ffi/src/client.rs
+++ b/ffi/rodbus-ffi/src/client.rs
@@ -1,5 +1,5 @@
 use crate::ffi;
-use rodbus::client::{ClientState, HostAddr, Listener, TlsClientConfig, WriteMultiple};
+use rodbus::client::{ClientState, HostAddr, Listener, WriteMultiple};
 use rodbus::{AddressRange, MaybeAsync};
 use std::net::IpAddr;
 
@@ -119,7 +119,7 @@ pub(crate) unsafe fn client_channel_create_tls(
 ) -> Result<*mut crate::ClientChannel, ffi::ParamError> {
     let runtime = runtime.as_ref().ok_or(ffi::ParamError::NullParameter)?;
 
-    let tls_config: TlsClientConfig = tls_config.try_into()?;
+    let tls_config: rodbus::client::TlsClientConfig = tls_config.try_into()?;
 
     let host_addr = get_host_addr(host, port)?;
 
@@ -399,7 +399,7 @@ impl From<ffi::PortStateListener> for Box<dyn Listener<rodbus::client::PortState
 }
 
 #[cfg(feature = "tls")]
-impl TryFrom<ffi::TlsClientConfig> for TlsClientConfig {
+impl TryFrom<ffi::TlsClientConfig> for rodbus::client::TlsClientConfig {
     type Error = ffi::ParamError;
 
     fn try_from(value: ffi::TlsClientConfig) -> Result<Self, Self::Error> {
@@ -425,7 +425,7 @@ impl TryFrom<ffi::TlsClientConfig> for TlsClientConfig {
                         Some(expected_subject_name.to_string())
                     };
 
-                TlsClientConfig::full_pki(
+                rodbus::client::TlsClientConfig::full_pki(
                     expected_subject_name,
                     peer_cert_path,
                     local_cert_path,
@@ -434,7 +434,7 @@ impl TryFrom<ffi::TlsClientConfig> for TlsClientConfig {
                     value.min_tls_version().into(),
                 )
             }
-            ffi::CertificateMode::SelfSigned => TlsClientConfig::self_signed(
+            ffi::CertificateMode::SelfSigned => rodbus::client::TlsClientConfig::self_signed(
                 peer_cert_path,
                 local_cert_path,
                 private_key_path,

--- a/ffi/rodbus-ffi/src/lib.rs
+++ b/ffi/rodbus-ffi/src/lib.rs
@@ -24,6 +24,7 @@ pub use iterator::*;
 pub use list::*;
 pub use runtime::*;
 pub use server::*;
+use std::str::Utf8Error;
 
 pub mod ffi;
 
@@ -63,5 +64,11 @@ impl From<crate::runtime::RuntimeError> for std::os::raw::c_int {
     fn from(err: crate::runtime::RuntimeError) -> Self {
         let err: crate::ffi::ParamError = err.into();
         err.into()
+    }
+}
+
+impl From<Utf8Error> for crate::ffi::ParamError {
+    fn from(_: Utf8Error) -> Self {
+        Self::InvalidUtf8
     }
 }

--- a/ffi/rodbus-schema/src/client.rs
+++ b/ffi/rodbus-schema/src/client.rs
@@ -465,6 +465,7 @@ fn build_tls_client_config(
 ) -> BackTraced<FunctionArgStructHandle> {
     let min_tls_version_field = Name::create("min_tls_version")?;
     let certificate_mode_field = Name::create("certificate_mode")?;
+    let allow_server_name_wildcard = Name::create("allow_server_name_wildcard")?;
 
     let tls_client_config = lib.declare_function_argument_struct("tls_client_config")?;
     let tls_client_config = lib.define_function_argument_struct(tls_client_config)?
@@ -495,11 +496,13 @@ fn build_tls_client_config(
             "Minimum TLS version allowed",
         )?
         .add(&certificate_mode_field, common.certificate_mode.clone(), "Certificate validation mode")?
+        .add(allow_server_name_wildcard.clone(), Primitive::Bool, "If set to true, a '*' may be used for {struct:tls_client_config.dns_name} to bypass server name validation")?
         .doc("TLS client configuration")?
         .end_fields()?
         .begin_initializer("init", InitializerType::Normal, "Initialize a TLS client configuration")?
         .default_variant(&min_tls_version_field, "v12")?
         .default_variant(&certificate_mode_field, "authority_based")?
+        .default(&allow_server_name_wildcard, false)?
         .end_initializer()?
         .build()?;
 

--- a/ffi/rodbus-schema/src/common.rs
+++ b/ffi/rodbus-schema/src/common.rs
@@ -125,6 +125,7 @@ fn build_error_type(lib: &mut LibraryBuilder) -> BackTraced<ErrorTypeHandle> {
         .add_error("invalid_dns_name", "Invalid DNS name")?
         .add_error("bad_tls_config", "Bad TLS configuration")?
         .add_error("shutdown", "The task has been shutdown")?
+        .add_error("invalid_utf8", "String argument was not valid UTF-8")?
         .doc("Error type that indicates a bad parameter or bad programmer logic")?
         .build()?;
 

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -116,14 +116,12 @@ async fn run_tls(tls_config: TlsClientConfig) -> Result<(), Box<dyn std::error::
 fn get_self_signed_config() -> Result<TlsClientConfig, Box<dyn std::error::Error>> {
     use std::path::Path;
     // ANCHOR: tls_self_signed_config
-    let tls_config = TlsClientConfig::new(
-        "test.com",
+    let tls_config = TlsClientConfig::self_signed(
         Path::new("./certs/self_signed/entity2_cert.pem"),
         Path::new("./certs/self_signed/entity1_cert.pem"),
         Path::new("./certs/self_signed/entity1_key.pem"),
         None, // no password
         MinTlsVersion::V1_2,
-        CertificateMode::SelfSigned,
     )?;
     // ANCHOR_END: tls_self_signed_config
 
@@ -134,14 +132,13 @@ fn get_self_signed_config() -> Result<TlsClientConfig, Box<dyn std::error::Error
 fn get_ca_chain_config() -> Result<TlsClientConfig, Box<dyn std::error::Error>> {
     use std::path::Path;
     // ANCHOR: tls_ca_chain_config
-    let tls_config = TlsClientConfig::new(
-        "test.com",
+    let tls_config = TlsClientConfig::full_pki(
+        Some("test.com".to_string()),
         Path::new("./certs/ca_chain/ca_cert.pem"),
         Path::new("./certs/ca_chain/client_cert.pem"),
         Path::new("./certs/ca_chain/client_key.pem"),
         None, // no password
         MinTlsVersion::V1_2,
-        CertificateMode::AuthorityBased,
     )?;
     // ANCHOR_END: tls_ca_chain_config
 

--- a/rodbus/src/tcp/tls/client.rs
+++ b/rodbus/src/tcp/tls/client.rs
@@ -1,4 +1,5 @@
 use std::convert::TryFrom;
+use std::net::Ipv4Addr;
 
 use sfio_rustls_config::NameVerifier;
 use std::path::Path;
@@ -17,7 +18,7 @@ use crate::DecodeLevel;
 
 /// TLS configuration
 pub struct TlsClientConfig {
-    dns_name: rustls::ServerName,
+    server_name: rustls::ServerName,
     config: Arc<rustls::ClientConfig>,
 }
 
@@ -67,9 +68,13 @@ pub(crate) fn create_tls_channel(
 }
 
 impl TlsClientConfig {
-    /// Create a TLS master config
+    /// Legacy method for creating a client TLS configuration
+    #[deprecated(
+        since = "1.3.0",
+        note = "Please use `full_pki` or `self_signed` instead"
+    )]
     pub fn new(
-        name: &str,
+        server_name: &str,
         peer_cert_path: &Path,
         local_cert_path: &Path,
         private_key_path: &Path,
@@ -77,29 +82,94 @@ impl TlsClientConfig {
         min_tls_version: MinTlsVersion,
         certificate_mode: CertificateMode,
     ) -> Result<Self, TlsError> {
-        let dns_name = rustls::ServerName::try_from(name).map_err(|_| TlsError::InvalidDnsName)?;
+        match certificate_mode {
+            CertificateMode::AuthorityBased => Self::full_pki(
+                Some(server_name.to_string()),
+                peer_cert_path,
+                local_cert_path,
+                private_key_path,
+                password,
+                min_tls_version,
+            ),
+            CertificateMode::SelfSigned => Self::self_signed(
+                peer_cert_path,
+                local_cert_path,
+                private_key_path,
+                password,
+                min_tls_version,
+            ),
+        }
+    }
 
-        let config = match certificate_mode {
-            CertificateMode::SelfSigned => sfio_rustls_config::client::self_signed(
-                min_tls_version.into(),
-                peer_cert_path,
-                local_cert_path,
-                private_key_path,
-                password,
-            )?,
-            CertificateMode::AuthorityBased => sfio_rustls_config::client::authority(
-                min_tls_version.into(),
-                NameVerifier::equal_to(name.to_string()),
-                peer_cert_path,
-                local_cert_path,
-                private_key_path,
-                password,
-            )?,
+    /// Create a TLS client configuration that expects a full PKI with an authority, and possibly
+    /// intermediate CA certificates.
+    ///
+    /// If `server_subject_name` is specified, than the client will verify that the name is present in the
+    /// SAN extension or in the Common Name of the client certificate.
+    ///
+    /// If `server_subject_name` is set to None, then no server name validation is performed, and
+    /// any authenticated server is allowed.
+    pub fn full_pki(
+        server_subject_name: Option<String>,
+        peer_cert_path: &Path,
+        local_cert_path: &Path,
+        private_key_path: &Path,
+        password: Option<&str>,
+        min_tls_version: MinTlsVersion,
+    ) -> Result<Self, TlsError> {
+        let (name_verifier, server_name) = match server_subject_name {
+            None => (
+                NameVerifier::any(),
+                rustls::ServerName::IpAddress(Ipv4Addr::UNSPECIFIED.into()),
+            ),
+            Some(x) => {
+                let server_name = rustls::ServerName::try_from(x.as_str())?;
+                (NameVerifier::equal_to(x), server_name)
+            }
         };
 
+        let config = sfio_rustls_config::client::authority(
+            min_tls_version.into(),
+            name_verifier,
+            peer_cert_path,
+            local_cert_path,
+            private_key_path,
+            password,
+        )?;
+
         Ok(Self {
+            server_name,
             config: Arc::new(config),
-            dns_name,
+        })
+    }
+
+    /// Create a TLS client configuration that expects the client to present a single certificate.
+    ///
+    /// In lieu of performing server subject name validation, the client validates:
+    ///
+    /// 1) That the server presents a single certificate
+    /// 2) That the certificate is a byte-for-byte match with the one loaded in `peer_cert_path`.
+    /// 3) That the certificate's Validity (not before / not after) is currently valid.
+    ///
+    pub fn self_signed(
+        peer_cert_path: &Path,
+        local_cert_path: &Path,
+        private_key_path: &Path,
+        password: Option<&str>,
+        min_tls_version: MinTlsVersion,
+    ) -> Result<Self, TlsError> {
+        let config = sfio_rustls_config::client::self_signed(
+            min_tls_version.into(),
+            peer_cert_path,
+            local_cert_path,
+            private_key_path,
+            password,
+        )?;
+
+        Ok(Self {
+            //  it doesn't matter what we put here, it just needs to be an IP so that the client won't send an SNI extension
+            server_name: rustls::ServerName::IpAddress(Ipv4Addr::UNSPECIFIED.into()),
+            config: Arc::new(config),
         })
     }
 
@@ -109,7 +179,7 @@ impl TlsClientConfig {
         endpoint: &HostAddr,
     ) -> Result<PhysLayer, String> {
         let connector = tokio_rustls::TlsConnector::from(self.config.clone());
-        match connector.connect(self.dns_name.clone(), socket).await {
+        match connector.connect(self.server_name.clone(), socket).await {
             Err(err) => Err(format!(
                 "failed to establish TLS session with {endpoint}: {err}"
             )),

--- a/rodbus/src/tcp/tls/mod.rs
+++ b/rodbus/src/tcp/tls/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod server;
 
 pub(crate) use client::*;
 pub(crate) use server::*;
+use tokio_rustls::rustls::client::InvalidDnsNameError;
 
 /// Determines how the certificate(s) presented by the peer are validated
 ///
@@ -81,5 +82,11 @@ impl From<MinTlsVersion> for sfio_rustls_config::MinProtocolVersion {
             MinTlsVersion::V1_2 => sfio_rustls_config::MinProtocolVersion::V1_2,
             MinTlsVersion::V1_3 => sfio_rustls_config::MinProtocolVersion::V1_3,
         }
+    }
+}
+
+impl From<InvalidDnsNameError> for TlsError {
+    fn from(_: InvalidDnsNameError) -> Self {
+        Self::InvalidDnsName
     }
 }


### PR DESCRIPTION
This feature can be activated by setting the `allow_server_name_wildcards` flag in TlsClientConfig to `true` in the bindings.