### PR TITLE
Update to oo-bindgen 0.8.7...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,9 +783,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oo-bindgen"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bdc3553c414516c4e287168049b1f97a89be4d80721bd480e206d97191e024"
+checksum = "73f5f798c35376fe2c8cdf364aa0a848f54330646a551100aa6273fa7c1156b8"
 dependencies = [
  "backtrace",
  "clap 4.5.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.dependencies]
-oo-bindgen = "0.8.6"
+oo-bindgen = "0.8.7"
 sfio-tokio-ffi = "0.9.0"
 sfio-tracing-ffi = "0.9.0"
 tokio = "1.37.0"


### PR DESCRIPTION
...  to get .NET assembly versions set correctly during build