### PR TITLE
Rodbus Client modernization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,15 +53,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,17 +121,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -269,21 +249,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
@@ -301,7 +266,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -542,15 +507,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -762,7 +718,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -788,7 +744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f5f798c35376fe2c8cdf364aa0a848f54330646a551100aa6273fa7c1156b8"
 dependencies = [
  "backtrace",
- "clap 4.5.7",
+ "clap",
  "dunce",
  "heck 0.4.1",
  "lazy_static",
@@ -953,7 +909,7 @@ dependencies = [
 name = "rodbus"
 version = "1.4.0"
 dependencies = [
- "clap 4.5.7",
+ "clap",
  "crc",
  "rx509",
  "scursor",
@@ -983,7 +939,7 @@ dependencies = [
 name = "rodbus-client"
 version = "1.4.0"
 dependencies = [
- "clap 2.34.0",
+ "clap",
  "rodbus",
  "tokio",
  "tracing",
@@ -1282,12 +1238,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -1307,15 +1257,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1530,12 +1471,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1552,12 +1487,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.61",
  "walkdir",
 ]
 
@@ -753,7 +753,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
  "tracing",
 ]
 
@@ -839,9 +839,9 @@ checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -941,6 +941,7 @@ version = "1.4.0"
 dependencies = [
  "clap",
  "rodbus",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1250,9 +1251,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.68"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1265,7 +1266,16 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.61",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1273,6 +1283,17 @@ name = "thiserror-impl"
 version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1461,7 +1482,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0adf6ad32eb5b3cadff915f7b770faaac8f7ff0476633aa29eb0d9584d889d34"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]

--- a/rodbus-client/Cargo.toml
+++ b/rodbus-client/Cargo.toml
@@ -22,7 +22,7 @@ name = "rodbus-client"
 path = "src/main.rs"
 
 [dependencies]
-rodbus = { path = "../rodbus", default-features = false }
+rodbus = { path = "../rodbus", features = ['serial']}
 clap = { version = "4.0", features = ["derive"] }
 tokio = { workspace = true, features = ["macros", "time"] }
 tracing = { workspace = true }

--- a/rodbus-client/Cargo.toml
+++ b/rodbus-client/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 
 [dependencies]
 rodbus = { path = "../rodbus", default-features = false }
-clap = "2.33"
+clap = { version = "4.0", features = ["derive"] }
 tokio = { workspace = true, features = ["macros", "time"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/rodbus-client/Cargo.toml
+++ b/rodbus-client/Cargo.toml
@@ -27,3 +27,4 @@ clap = { version = "4.0", features = ["derive"] }
 tokio = { workspace = true, features = ["macros", "time"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+thiserror = { version = "2.0.12" }

--- a/rodbus-client/src/main.rs
+++ b/rodbus-client/src/main.rs
@@ -75,7 +75,12 @@ enum Mode {
 /// Settings for initializing a serial connection
 #[derive(Clone, Args, Copy)]
 struct ModeSerialSettings {
-    #[arg(short = 'b', long, default_value = "9600", help = "baud rate of the device")]
+    #[arg(
+        short = 'b',
+        long,
+        default_value = "9600",
+        help = "baud rate of the device"
+    )]
     baud_rate: u32,
     #[arg(short = 'd', long, default_value = "8", help = "data bits of the device", value_parser = parse_data_bits )]
     data_bits: DataBits,
@@ -224,15 +229,15 @@ struct StateListener<T> {
 }
 
 impl<T> StateListener<T> {
-       fn create() -> (Self, tokio::sync::mpsc::Receiver<T>) {
+    fn create() -> (Self, tokio::sync::mpsc::Receiver<T>) {
         let (tx, rx) = tokio::sync::mpsc::channel(CHANNEL_BUFFER_SIZE);
         (Self { tx }, rx)
     }
 }
 
 impl<T> Listener<T> for StateListener<T>
-where 
-    T: Send + 'static
+where
+    T: Send + 'static,
 {
     fn update(&mut self, state: T) -> MaybeAsync<()> {
         let tx = self.tx.clone();
@@ -279,8 +284,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
-
-async fn setup_channel( mode: Mode ) -> Result<(Channel, Command), Box<dyn std::error::Error>> {
+async fn setup_channel(mode: Mode) -> Result<(Channel, Command), Box<dyn std::error::Error>> {
     let (channel, command) = match mode {
         Mode::Tcp { host, command } => {
             let (listener, mut rx) = StateListener::create();
@@ -305,7 +309,11 @@ async fn setup_channel( mode: Mode ) -> Result<(Channel, Command), Box<dyn std::
             }
             (channel, command)
         }
-        Mode::Serial { path, settings, command } => {
+        Mode::Serial {
+            path,
+            settings,
+            command,
+        } => {
             let settings: SerialSettings = settings.into();
             let (listener, mut rx) = StateListener::create();
             let channel = spawn_rtu_client_task(

--- a/rodbus-client/src/main.rs
+++ b/rodbus-client/src/main.rs
@@ -25,45 +25,139 @@ enum Error {
 
 #[derive(Parser)]
 #[command(name = "rodbus-client")]
-#[command(about = "A command line program for making Modbus client requests using the Rodbus crate")]
+#[command(
+    about = "A command line program for making Modbus client requests using the Rodbus crate"
+)]
 #[command(version = "1.4.0")]
 struct Cli {
-    #[arg(long, default_value = "127.0.0.1:502", help = "A socket address")]
-    host: SocketAddr,
-    
-    #[arg(short = 'i', long, default_value = "1", help = "The unit id of Modbus server")]
+    #[arg(
+        short = 'i',
+        long,
+        default_value = "1",
+        help = "The unit id of Modbus server"
+    )]
     id: u8,
-    
+
     #[arg(short = 'p', long, help = "Optional polling period in milliseconds")]
     period: Option<u64>,
-    
+
     #[command(subcommand)]
-    command: Command,
+    mode: Mode,
+}
+
+#[derive(Subcommand)]
+enum Mode {
+    #[command(name = "tcp", about = "use the TCP protocol")]
+    Tcp {
+        #[arg(long, default_value = "127.0.0.1:502", help = "address of the socket")]
+        host: SocketAddr,
+
+        #[command(subcommand)]
+        command: Command,
+    },
+    #[command(name = "serial", about = "use the serial protocol")]
+    Serial {
+        #[command(flatten)]
+        settings: ModeSerialSettings,
+
+        #[arg(short = 'p', long, help = "the serial port path")]
+        path: String,
+
+        #[command(subcommand)]
+        command: Command,
+    },
+}
+
+/// Settings for initializing a serial connection
+#[derive(Clone, Args, Copy)]
+struct ModeSerialSettings {
+    #[arg(short = 'b', long, default_value = "9600", help = "baud rate of the device")]
+    baud_rate: u32,
+    #[arg(short = 'd', long, default_value = "8", help = "data bits of the device", value_parser = parse_data_bits )]
+    data_bits: DataBits,
+    #[arg(short = 'f', long, default_value = "none", help = "flow control of the device", value_parser = parse_flow_control)]
+    flow_control: FlowControl,
+    #[arg(short = 's', long, default_value = "1", help = "stop bits of the device", value_parser = parse_stop_bits)]
+    stop_bits: StopBits,
+    #[arg(long, default_value = "none", help = "parity of the device", value_parser = parse_parity)]
+    parity: Parity,
+}
+
+impl From<ModeSerialSettings> for SerialSettings {
+    fn from(settings: ModeSerialSettings) -> Self {
+        Self {
+            baud_rate: settings.baud_rate,
+            data_bits: settings.data_bits,
+            flow_control: settings.flow_control,
+            stop_bits: settings.stop_bits,
+            parity: settings.parity,
+        }
+    }
+}
+
+fn parse_data_bits(s: &str) -> Result<DataBits, String> {
+    match s {
+        "5" => Ok(DataBits::Five),
+        "6" => Ok(DataBits::Six),
+        "7" => Ok(DataBits::Seven),
+        "8" => Ok(DataBits::Eight),
+        _ => Err(format!("invalid data bits: {s}")),
+    }
+}
+
+fn parse_flow_control(s: &str) -> Result<FlowControl, String> {
+    match s {
+        "none" => Ok(FlowControl::None),
+        "software" => Ok(FlowControl::Software),
+        "hardware" => Ok(FlowControl::Hardware),
+        _ => Err(format!(
+            "invalid flow control: {s}, expected one of: none, software, hardware"
+        )),
+    }
+}
+
+fn parse_stop_bits(s: &str) -> Result<StopBits, String> {
+    match s {
+        "1" => Ok(StopBits::One),
+        "2" => Ok(StopBits::Two),
+        _ => Err(format!("invalid stop bits: {s}, expected one of: 1, 2")),
+    }
+}
+
+fn parse_parity(s: &str) -> Result<Parity, String> {
+    match s {
+        "none" => Ok(Parity::None),
+        "odd" => Ok(Parity::Odd),
+        "even" => Ok(Parity::Even),
+        _ => Err(format!(
+            "invalid parity: {s}, expected one of: none, odd, even"
+        )),
+    }
 }
 
 #[derive(Subcommand)]
 enum Command {
     #[command(name = "rc", about = "read coils")]
     ReadCoils(ReadArgs),
-    
+
     #[command(name = "rdi", about = "read discrete inputs")]
     ReadDiscreteInputs(ReadArgs),
-    
+
     #[command(name = "rhr", about = "read holding registers")]
     ReadHoldingRegisters(ReadArgs),
-    
+
     #[command(name = "rir", about = "read input registers")]
     ReadInputRegisters(ReadArgs),
-    
+
     #[command(name = "wsc", about = "write single coil")]
     WriteSingleCoil(WriteSingleCoilArgs),
-    
+
     #[command(name = "wsr", about = "write single register")]
     WriteSingleRegister(WriteSingleRegisterArgs),
-    
+
     #[command(name = "wmc", about = "write multiple coils")]
     WriteMultipleCoils(WriteMultipleCoilsArgs),
-    
+
     #[command(name = "wmr", about = "write multiple registers")]
     WriteMultipleRegisters(WriteMultipleRegistersArgs),
 }
@@ -72,7 +166,7 @@ enum Command {
 struct ReadArgs {
     #[arg(short = 's', long, help = "the starting address")]
     start: u16,
-    
+
     #[arg(short = 'q', long, help = "quantity of values")]
     quantity: u16,
 }
@@ -81,7 +175,7 @@ struct ReadArgs {
 struct WriteSingleCoilArgs {
     #[arg(short = 'i', long, help = "the address of the coil")]
     index: u16,
-    
+
     #[arg(short = 'v', long, help = "the value of the coil (ON or OFF)")]
     value: bool,
 }
@@ -90,7 +184,7 @@ struct WriteSingleCoilArgs {
 struct WriteSingleRegisterArgs {
     #[arg(short = 'i', long, help = "the address of the register")]
     index: u16,
-    
+
     #[arg(short = 'v', long, help = "the value of the register")]
     value: u16,
 }
@@ -99,8 +193,12 @@ struct WriteSingleRegisterArgs {
 struct WriteMultipleCoilsArgs {
     #[arg(short = 's', long, help = "the starting address of the coils")]
     start: u16,
-    
-    #[arg(short = 'v', long, help = "the values of the coils specified as a string of 1 and 0 (e.g. 10100011)")]
+
+    #[arg(
+        short = 'v',
+        long,
+        help = "the values of the coils specified as a string of 1 and 0 (e.g. 10100011)"
+    )]
     values: String,
 }
 
@@ -108,24 +206,31 @@ struct WriteMultipleCoilsArgs {
 struct WriteMultipleRegistersArgs {
     #[arg(short = 's', long, help = "the starting address of the registers")]
     start: u16,
-    
-    #[arg(short = 'v', long, help = "the values of the registers specified as a comma delimited list (e.g. 1,4,7)")]
+
+    #[arg(
+        short = 'v',
+        long,
+        help = "the values of the registers specified as a comma delimited list (e.g. 1,4,7)"
+    )]
     values: String,
 }
 
-struct ConnectionListener {
-    tx: tokio::sync::mpsc::Sender<ClientState>,
+struct StateListener<T> {
+    tx: tokio::sync::mpsc::Sender<T>,
 }
 
-impl ConnectionListener {
-    fn create() -> (Self, tokio::sync::mpsc::Receiver<ClientState>) {
+impl<T> StateListener<T> {
+       fn create() -> (Self, tokio::sync::mpsc::Receiver<T>) {
         let (tx, rx) = tokio::sync::mpsc::channel(32);
         (Self { tx }, rx)
     }
 }
 
-impl Listener<ClientState> for ConnectionListener {
-    fn update(&mut self, state: ClientState) -> MaybeAsync<()> {
+impl<T> Listener<T> for StateListener<T>
+where 
+    T: Send + 'static
+{
+    fn update(&mut self, state: T) -> MaybeAsync<()> {
         let tx = self.tx.clone();
         let future = async move {
             let _ = tx.try_send(state);
@@ -133,7 +238,6 @@ impl Listener<ClientState> for ConnectionListener {
         MaybeAsync::asynchronous(future)
     }
 }
-
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -153,39 +257,83 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
-    let (listener, mut rx) = ConnectionListener::create();
-
-    let mut channel = spawn_tcp_client_task(
-        HostAddr::ip(cli.host.ip(), cli.host.port()),
-        1,
-        default_retry_strategy(),
-        AppDecodeLevel::DataValues.into(),
-        Some(Box::new(listener)),
-    );
-    channel.enable().await?;
-
-    'connect: loop {
-        let state = rx.recv().await.expect("should never be empty");
-        tracing::info!("state: {state:?}");
-        match state {
-            ClientState::Disabled | ClientState::Connecting => {}
-            ClientState::Connected => break 'connect,
-            _ => return Err("unable to connect".into()),
-        }
-    }
+    let (mut channel, command) = setup_channel(cli.mode).await?;
 
     let params = RequestParam::new(UnitId::new(cli.id), Duration::from_secs(1));
 
     match cli.period {
-        None => run_command(&cli.command, &mut channel, params).await.map_err(Into::into),
+        None => run_command(&command, &mut channel, params)
+            .await
+            .map_err(Into::into),
         Some(period_ms) => {
             let period = Duration::from_millis(period_ms);
             loop {
-                run_command(&cli.command, &mut channel, params).await?;
+                run_command(&command, &mut channel, params).await?;
                 tokio::time::sleep(period).await
             }
-        },
+        }
     }
+}
+
+
+async fn setup_channel( mode: Mode ) -> Result<(Channel, Command), Box<dyn std::error::Error>> {
+    let (channel, command) = match mode {
+        Mode::Tcp { host, command } => {
+            let (listener, mut rx) = StateListener::create();
+            let channel = spawn_tcp_client_task(
+                HostAddr::ip(host.ip(), host.port()),
+                1,
+                default_retry_strategy(),
+                AppDecodeLevel::DataValues.into(),
+                Some(Box::new(listener)),
+            );
+
+            channel.enable().await?;
+
+            'connect: loop {
+                let state = rx.recv().await.expect("should never be empty");
+                tracing::info!("state: {state:?}");
+                match state {
+                    ClientState::Disabled | ClientState::Connecting => {}
+                    ClientState::Connected => break 'connect,
+                    _ => return Err("unable to connect".into()),
+                }
+            }
+            (channel, command)
+        }
+        Mode::Serial { path, settings, command } => {
+            let settings: SerialSettings = settings.into();
+            let (listener, mut rx) = StateListener::create();
+            let channel = spawn_rtu_client_task(
+                &path,
+                settings,
+                1,
+                default_retry_strategy(),
+                DecodeLevel {
+                    app: AppDecodeLevel::DataValues,
+                    frame: FrameDecodeLevel::Payload,
+                    physical: PhysDecodeLevel::Nothing,
+                },
+                Some(Box::new(listener)),
+            );
+
+            channel.enable().await?;
+
+            'connect: loop {
+                let state = rx.recv().await.expect("should never be empty");
+                tracing::info!("state: {state:?}");
+                match state {
+                    PortState::Disabled | PortState::Wait(_) => {}
+                    PortState::Open => break 'connect,
+                    PortState::Shutdown => return Err("unable to connect".into()),
+                }
+            }
+
+            (channel, command)
+        }
+    };
+
+    Ok((channel, command))
 }
 
 async fn run_command(
@@ -234,7 +382,9 @@ async fn run_command(
         Command::WriteMultipleRegisters(args) => {
             let values = parse_register_values(&args.values)?;
             let write_multiple = WriteMultiple::from(args.start, values)?;
-            channel.write_multiple_registers(params, write_multiple).await?;
+            channel
+                .write_multiple_registers(params, write_multiple)
+                .await?;
         }
     }
     Ok(())

--- a/rodbus-client/src/main.rs
+++ b/rodbus-client/src/main.rs
@@ -280,8 +280,7 @@ async fn run() -> Result<(), Error> {
     let params = RequestParam::new(UnitId::new(cli.id), REQUEST_TIMEOUT);
 
     match cli.period {
-        None => run_command(&command, &mut channel, params)
-            .await,
+        None => run_command(&command, &mut channel, params).await,
         Some(period_ms) => {
             let period = Duration::from_millis(period_ms);
             loop {

--- a/rodbus-client/src/main.rs
+++ b/rodbus-client/src/main.rs
@@ -6,7 +6,7 @@ use std::num::ParseIntError;
 use std::str::{FromStr, ParseBoolError};
 use std::time::Duration;
 
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{Args, Parser, Subcommand};
 
 use rodbus::client::*;
 use rodbus::*;
@@ -20,26 +20,97 @@ enum Error {
     BadBool(std::str::ParseBoolError),
     BadCharInBitString(char),
     Request(rodbus::RequestError),
-    MissingSubCommand,
     Shutdown,
 }
 
-enum Command {
-    ReadCoils(AddressRange),
-    ReadDiscreteInputs(AddressRange),
-    ReadHoldingRegisters(AddressRange),
-    ReadInputRegisters(AddressRange),
-    WriteSingleRegister(Indexed<u16>),
-    WriteSingleCoil(Indexed<bool>),
-    WriteMultipleCoils(WriteMultiple<bool>),
-    WriteMultipleRegisters(WriteMultiple<u16>),
+#[derive(Parser)]
+#[command(name = "rodbus-client")]
+#[command(about = "A command line program for making Modbus client requests using the Rodbus crate")]
+#[command(version = "1.4.0")]
+struct Cli {
+    #[arg(long, default_value = "127.0.0.1:502", help = "A socket address")]
+    host: SocketAddr,
+    
+    #[arg(short = 'i', long, default_value = "1", help = "The unit id of Modbus server")]
+    id: u8,
+    
+    #[arg(short = 'p', long, help = "Optional polling period in milliseconds")]
+    period: Option<u64>,
+    
+    #[command(subcommand)]
+    command: Command,
 }
 
-struct Args {
-    address: SocketAddr,
-    id: UnitId,
-    command: Command,
-    period: Option<Duration>,
+#[derive(Subcommand)]
+enum Command {
+    #[command(name = "rc", about = "read coils")]
+    ReadCoils(ReadArgs),
+    
+    #[command(name = "rdi", about = "read discrete inputs")]
+    ReadDiscreteInputs(ReadArgs),
+    
+    #[command(name = "rhr", about = "read holding registers")]
+    ReadHoldingRegisters(ReadArgs),
+    
+    #[command(name = "rir", about = "read input registers")]
+    ReadInputRegisters(ReadArgs),
+    
+    #[command(name = "wsc", about = "write single coil")]
+    WriteSingleCoil(WriteSingleCoilArgs),
+    
+    #[command(name = "wsr", about = "write single register")]
+    WriteSingleRegister(WriteSingleRegisterArgs),
+    
+    #[command(name = "wmc", about = "write multiple coils")]
+    WriteMultipleCoils(WriteMultipleCoilsArgs),
+    
+    #[command(name = "wmr", about = "write multiple registers")]
+    WriteMultipleRegisters(WriteMultipleRegistersArgs),
+}
+
+#[derive(Args)]
+struct ReadArgs {
+    #[arg(short = 's', long, help = "the starting address")]
+    start: u16,
+    
+    #[arg(short = 'q', long, help = "quantity of values")]
+    quantity: u16,
+}
+
+#[derive(Args)]
+struct WriteSingleCoilArgs {
+    #[arg(short = 'i', long, help = "the address of the coil")]
+    index: u16,
+    
+    #[arg(short = 'v', long, help = "the value of the coil (ON or OFF)")]
+    value: bool,
+}
+
+#[derive(Args)]
+struct WriteSingleRegisterArgs {
+    #[arg(short = 'i', long, help = "the address of the register")]
+    index: u16,
+    
+    #[arg(short = 'v', long, help = "the value of the register")]
+    value: u16,
+}
+
+#[derive(Args)]
+struct WriteMultipleCoilsArgs {
+    #[arg(short = 's', long, help = "the starting address of the coils")]
+    start: u16,
+    
+    #[arg(short = 'v', long, help = "the values of the coils specified as a string of 1 and 0 (e.g. 10100011)")]
+    values: String,
+}
+
+#[derive(Args)]
+struct WriteMultipleRegistersArgs {
+    #[arg(short = 's', long, help = "the starting address of the registers")]
+    start: u16,
+    
+    #[arg(short = 'v', long, help = "the values of the registers specified as a comma delimited list (e.g. 1,4,7)")]
+    values: String,
 }
 
 struct ConnectionListener {
@@ -63,16 +134,6 @@ impl Listener<ClientState> for ConnectionListener {
     }
 }
 
-impl Args {
-    fn new(address: SocketAddr, id: UnitId, command: Command, period: Option<Duration>) -> Self {
-        Self {
-            address,
-            id,
-            command,
-            period,
-        }
-    }
-}
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -90,12 +151,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    let args = parse_args()?;
+    let cli = Cli::parse();
 
     let (listener, mut rx) = ConnectionListener::create();
 
     let mut channel = spawn_tcp_client_task(
-        HostAddr::ip(args.address.ip(), args.address.port()),
+        HostAddr::ip(cli.host.ip(), cli.host.port()),
         1,
         default_retry_strategy(),
         AppDecodeLevel::DataValues.into(),
@@ -113,13 +174,16 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let params = RequestParam::new(args.id, Duration::from_secs(1));
+    let params = RequestParam::new(UnitId::new(cli.id), Duration::from_secs(1));
 
-    match args.period {
-        None => run_command(&args.command, &mut channel, params).await,
-        Some(period) => loop {
-            run_command(&args.command, &mut channel, params).await?;
-            tokio::time::sleep(period).await
+    match cli.period {
+        None => run_command(&cli.command, &mut channel, params).await.map_err(Into::into),
+        Some(period_ms) => {
+            let period = Duration::from_millis(period_ms);
+            loop {
+                run_command(&cli.command, &mut channel, params).await?;
+                tokio::time::sleep(period).await
+            }
         },
     }
 }
@@ -128,63 +192,57 @@ async fn run_command(
     command: &Command,
     channel: &mut Channel,
     params: RequestParam,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Error> {
     match command {
-        Command::ReadCoils(range) => {
-            for x in channel.read_coils(params, *range).await? {
+        Command::ReadCoils(args) => {
+            let range = AddressRange::try_from(args.start, args.quantity)?;
+            for x in channel.read_coils(params, range).await? {
                 println!("index: {} value: {}", x.index, x.value)
             }
         }
-        Command::ReadDiscreteInputs(range) => {
-            for x in channel.read_discrete_inputs(params, *range).await? {
+        Command::ReadDiscreteInputs(args) => {
+            let range = AddressRange::try_from(args.start, args.quantity)?;
+            for x in channel.read_discrete_inputs(params, range).await? {
                 println!("index: {} value: {}", x.index, x.value)
             }
         }
-        Command::ReadHoldingRegisters(range) => {
-            for x in channel.read_holding_registers(params, *range).await? {
+        Command::ReadHoldingRegisters(args) => {
+            let range = AddressRange::try_from(args.start, args.quantity)?;
+            for x in channel.read_holding_registers(params, range).await? {
                 println!("index: {} value: {}", x.index, x.value)
             }
         }
-        Command::ReadInputRegisters(range) => {
-            for x in channel.read_input_registers(params, *range).await? {
+        Command::ReadInputRegisters(args) => {
+            let range = AddressRange::try_from(args.start, args.quantity)?;
+            for x in channel.read_input_registers(params, range).await? {
                 println!("index: {} value: {}", x.index, x.value)
             }
         }
-        Command::WriteSingleRegister(arg) => {
-            channel.write_single_register(params, *arg).await?;
+        Command::WriteSingleRegister(args) => {
+            let indexed = Indexed::new(args.index, args.value);
+            channel.write_single_register(params, indexed).await?;
         }
-        Command::WriteSingleCoil(arg) => {
-            channel.write_single_coil(params, *arg).await?;
+        Command::WriteSingleCoil(args) => {
+            let indexed = Indexed::new(args.index, args.value);
+            channel.write_single_coil(params, indexed).await?;
         }
-        Command::WriteMultipleCoils(arg) => {
-            channel.write_multiple_coils(params, arg.clone()).await?;
+        Command::WriteMultipleCoils(args) => {
+            let values = parse_bit_values(&args.values)?;
+            let write_multiple = WriteMultiple::from(args.start, values)?;
+            channel.write_multiple_coils(params, write_multiple).await?;
         }
-        Command::WriteMultipleRegisters(arg) => {
-            channel
-                .write_multiple_registers(params, arg.clone())
-                .await?;
+        Command::WriteMultipleRegisters(args) => {
+            let values = parse_register_values(&args.values)?;
+            let write_multiple = WriteMultiple::from(args.start, values)?;
+            channel.write_multiple_registers(params, write_multiple).await?;
         }
     }
     Ok(())
 }
 
-fn get_index(arg: &ArgMatches) -> Result<u16, ParseIntError> {
-    u16::from_str(arg.value_of("index").unwrap())
-}
-
-fn get_start(arg: &ArgMatches) -> Result<u16, ParseIntError> {
-    u16::from_str(arg.value_of("start").unwrap())
-}
-
-fn get_value(arg: &ArgMatches) -> Result<u16, ParseIntError> {
-    u16::from_str(arg.value_of("value").unwrap())
-}
-
-fn get_bit_values(arg: &ArgMatches) -> Result<Vec<bool>, Error> {
-    let str = arg.value_of("values").unwrap();
-
+fn parse_bit_values(values_str: &str) -> Result<Vec<bool>, Error> {
     let mut values: Vec<bool> = Vec::new();
-    for c in str.chars().rev() {
+    for c in values_str.chars().rev() {
         match c {
             '0' => values.push(false),
             '1' => values.push(true),
@@ -194,282 +252,12 @@ fn get_bit_values(arg: &ArgMatches) -> Result<Vec<bool>, Error> {
     Ok(values)
 }
 
-fn get_register_values(arg: &ArgMatches) -> Result<Vec<u16>, ParseIntError> {
-    let str = arg.value_of("values").unwrap();
-
+fn parse_register_values(values_str: &str) -> Result<Vec<u16>, ParseIntError> {
     let mut values: Vec<u16> = Vec::new();
-    for value in str.split(',') {
+    for value in values_str.split(',') {
         values.push(u16::from_str(value)?);
     }
     Ok(values)
-}
-
-fn get_quantity(arg: &ArgMatches) -> Result<u16, ParseIntError> {
-    u16::from_str(arg.value_of("quantity").unwrap())
-}
-
-fn get_period_ms(value: &str) -> Result<Duration, ParseIntError> {
-    let num = usize::from_str(value)?;
-    Ok(Duration::from_millis(num as u64))
-}
-
-fn get_address_range(arg: &ArgMatches) -> Result<AddressRange, Error> {
-    Ok(AddressRange::try_from(get_start(arg)?, get_quantity(arg)?)?)
-}
-
-fn get_indexed_register_value(arg: &ArgMatches) -> Result<Indexed<u16>, Error> {
-    Ok(Indexed::new(get_index(arg)?, get_value(arg)?))
-}
-
-fn get_command(matches: &ArgMatches) -> Result<Command, Error> {
-    if let Some(matches) = matches.subcommand_matches("rc") {
-        return Ok(Command::ReadCoils(get_address_range(matches)?));
-    }
-
-    if let Some(matches) = matches.subcommand_matches("rdi") {
-        return Ok(Command::ReadDiscreteInputs(get_address_range(matches)?));
-    }
-
-    if let Some(matches) = matches.subcommand_matches("rhr") {
-        return Ok(Command::ReadHoldingRegisters(get_address_range(matches)?));
-    }
-
-    if let Some(matches) = matches.subcommand_matches("rir") {
-        return Ok(Command::ReadInputRegisters(get_address_range(matches)?));
-    }
-
-    if let Some(matches) = matches.subcommand_matches("wsr") {
-        return Ok(Command::WriteSingleRegister(get_indexed_register_value(
-            matches,
-        )?));
-    }
-
-    if let Some(matches) = matches.subcommand_matches("wsc") {
-        let index = get_index(matches)?;
-        let value = bool::from_str(matches.value_of("value").unwrap())?;
-        return Ok(Command::WriteSingleCoil(Indexed::new(index, value)));
-    }
-
-    if let Some(matches) = matches.subcommand_matches("wmc") {
-        let start = get_start(matches)?;
-        let values = get_bit_values(matches)?;
-        return Ok(Command::WriteMultipleCoils(WriteMultiple::from(
-            start, values,
-        )?));
-    }
-
-    if let Some(matches) = matches.subcommand_matches("wmr") {
-        let start = get_start(matches)?;
-        let values = get_register_values(matches)?;
-        return Ok(Command::WriteMultipleRegisters(WriteMultiple::from(
-            start, values,
-        )?));
-    }
-
-    Err(Error::MissingSubCommand)
-}
-
-fn parse_args() -> Result<Args, Error> {
-    let matches = App::new("Modbus Client Console")
-        .version("0.1.0")
-        .about("Simple program to show off client API")
-        .arg(
-            Arg::with_name("host")
-                .short("h")
-                .long("host")
-                .takes_value(true)
-                .required(false)
-                .default_value("127.0.0.1:502")
-                .help("A socket address"),
-        )
-        .arg(
-            Arg::with_name("id")
-                .short("i")
-                .long("id")
-                .takes_value(true)
-                .required(false)
-                .default_value("1")
-                .help("The unit id of Modbus server"),
-        )
-        .arg(
-            Arg::with_name("period")
-                .short("p")
-                .long("period")
-                .takes_value(true)
-                .required(false)
-                .help("Optional polling period in milliseconds"),
-        )
-        .subcommand(
-            SubCommand::with_name("rc")
-                .about("read coils")
-                .arg(
-                    Arg::with_name("start")
-                        .short("s")
-                        .long("start")
-                        .required(true)
-                        .takes_value(true)
-                        .help("the starting address"),
-                )
-                .arg(
-                    Arg::with_name("quantity")
-                        .short("q")
-                        .long("quantity")
-                        .required(true)
-                        .takes_value(true)
-                        .help("quantity of values"),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("rdi")
-                .about("read discrete inputs")
-                .arg(
-                    Arg::with_name("start")
-                        .short("s")
-                        .long("start")
-                        .required(true)
-                        .takes_value(true)
-                        .help("the starting address"),
-                )
-                .arg(
-                    Arg::with_name("quantity")
-                        .short("q")
-                        .long("quantity")
-                        .required(true)
-                        .takes_value(true)
-                        .help("quantity of values"),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("rhr")
-                .about("read holding registers")
-                .arg(
-                    Arg::with_name("start")
-                        .short("s")
-                        .long("start")
-                        .required(true)
-                        .takes_value(true)
-                        .help("the starting address"),
-                )
-                .arg(
-                    Arg::with_name("quantity")
-                        .short("q")
-                        .long("quantity")
-                        .required(true)
-                        .takes_value(true)
-                        .help("quantity of values"),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("rir")
-                .about("read input registers")
-                .arg(
-                    Arg::with_name("start")
-                        .short("s")
-                        .long("start")
-                        .required(true)
-                        .takes_value(true)
-                        .help("the starting address"),
-                )
-                .arg(
-                    Arg::with_name("quantity")
-                        .short("q")
-                        .long("quantity")
-                        .required(true)
-                        .takes_value(true)
-                        .help("quantity of values"),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("wsc")
-                .about("write single coil")
-                .arg(
-                    Arg::with_name("index")
-                        .short("i")
-                        .long("index")
-                        .required(true)
-                        .takes_value(true)
-                        .help("the address of the coil"),
-                )
-                .arg(
-                    Arg::with_name("value")
-                        .short("v")
-                        .long("value")
-                        .required(true)
-                        .takes_value(true)
-                        .help("the value of the coil (ON or OFF)"),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("wsr")
-                .about("write single register")
-                .arg(
-                    Arg::with_name("index")
-                        .short("i")
-                        .long("index")
-                        .required(true)
-                        .takes_value(true)
-                        .help("the address of the register"),
-                )
-                .arg(
-                    Arg::with_name("value")
-                        .short("v")
-                        .long("value")
-                        .required(true)
-                        .takes_value(true)
-                        .help("the value of the register"),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("wmc")
-                .about("write multiple coils")
-                .arg(
-                    Arg::with_name("start")
-                        .short("s")
-                        .long("start")
-                        .required(true)
-                        .takes_value(true)
-                        .help("the starting address of the coils"),
-                )
-                .arg(
-                    Arg::with_name("values")
-                        .short("v")
-                        .long("values")
-                        .required(true)
-                        .takes_value(true)
-                        .help("the values of the coils specified as a string of 1 and 0 (e.g. 10100011)"),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("wmr")
-                .about("write multiple registers")
-                .arg(
-                    Arg::with_name("start")
-                        .short("s")
-                        .long("start")
-                        .required(true)
-                        .takes_value(true)
-                        .help("the starting address of the registers"),
-                )
-                .arg(
-                    Arg::with_name("values")
-                        .short("v")
-                        .long("values")
-                        .required(true)
-                        .takes_value(true)
-                        .help("the values of the registers specified as a comma delimited list (e.g. 1,4,7)"),
-                ),
-        )
-        .get_matches();
-
-    let address = SocketAddr::from_str(matches.value_of("host").unwrap())?;
-    let id = UnitId::new(u8::from_str(matches.value_of("id").unwrap())?);
-    let period = match matches.value_of("period") {
-        Some(s) => Some(get_period_ms(s)?),
-        None => None,
-    };
-    let command = get_command(&matches)?;
-
-    Ok(Args::new(address, id, command, period))
 }
 
 impl std::error::Error for Error {}
@@ -483,7 +271,6 @@ impl std::fmt::Display for Error {
             Error::BadBool(err) => err.fmt(f),
             Error::BadCharInBitString(char) => write!(f, "Bad character in bit string: {char}"),
             Error::Request(err) => err.fmt(f),
-            Error::MissingSubCommand => f.write_str("No sub-command provided"),
             Error::Shutdown => f.write_str("channel was shut down"),
         }
     }

--- a/rodbus-client/src/main.rs
+++ b/rodbus-client/src/main.rs
@@ -32,8 +32,8 @@ enum Error {
     Request(rodbus::RequestError),
     #[error("Channel was shutdown")]
     Shutdown,
-    #[error("{0}")]
-    Message(String),
+    #[error("Unable to connect: {0}")]
+    UnableToConnect(String),
 }
 
 #[derive(Parser)]
@@ -473,6 +473,6 @@ impl From<Shutdown> for Error {
 
 impl From<&str> for Error {
     fn from(msg: &str) -> Self {
-        Self::Message(msg.to_string())
+        Self::UnableToConnect(msg.to_string())
     }
 }


### PR DESCRIPTION
This completes #151.

- [ ] Update `clap` using V4's `derive` macro
- [ ] Add Serial support
- [ ] Migrate `Box<Dyn std::error:Error>> to thiserror
- [ ] Extract magic numbers into constants