### PR TITLE
ci: fix Maven GPG import input name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,7 +362,7 @@ jobs:
       - name: Import PGP key
         uses: crazy-max/ghaction-import-gpg@v7
         with:
-          gpg-private-key: ${{ secrets.SFIO_PGP_PRIVATE_KEY }}
+          gpg_private_key: ${{ secrets.SFIO_PGP_PRIVATE_KEY }}
           passphrase: ${{ secrets.SFIO_PGP_PRIVATE_KEY_PASSPHRASE }}
       - name: Deploy Java to Maven Central
         shell: bash


### PR DESCRIPTION
## Problem

The `release-maven` job in the `1.5.0-RC2` release failed at the **Import PGP key** step:

```
##[warning]Unexpected input(s) 'gpg-private-key', valid inputs are ['gpg_private_key', 'passphrase', ...]
##[error]Input required and not supplied: gpg_private_key
```

`crazy-max/ghaction-import-gpg@v7` expects the input `gpg_private_key` (underscore). The workflow passed `gpg-private-key` (hyphen), which was silently ignored, so the required key was never supplied and the step errored before the Maven deploy ran. (The `SFIO_PGP_PRIVATE_KEY` secret itself is fine — the value was present but bound to an unrecognized input name.)

## Fix

Rename the input `gpg-private-key` → `gpg_private_key`. `passphrase` was already correct.

## Note

crates.io, NuGet, and docs all published successfully for 1.5.0-RC2; only Maven Central and the dependent GitHub release were blocked. After this merges, the `1.5.0-RC2` tag needs to be re-pointed at the fixed commit and re-pushed to re-run the pipeline (the crates.io/NuGet jobs skip if the version already exists).