### PR TITLE
ci: fix Maven GPG signing and crates.io idempotency for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,7 @@ jobs:
           path: artifacts
           pattern: java-bindings-*
       - name: Import PGP key
+        id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v7
         with:
           gpg_private_key: ${{ secrets.SFIO_PGP_PRIVATE_KEY }}
@@ -389,10 +390,12 @@ jobs:
             cp java-bindings-jar/rodbus-${{github.ref_name}}-sources.jar io/stepfunc/rodbus/${{github.ref_name}}/
             cp java-bindings-jar/rodbus-${{github.ref_name}}-javadoc.jar io/stepfunc/rodbus/${{github.ref_name}}/
 
-            # Sign all files
+            # Sign all files. v7 of ghaction-import-gpg does not configure a default
+            # signing key, so select it explicitly by fingerprint (the action's
+            # recommended user ID) to avoid "no default secret key" errors.
             cd io/stepfunc/rodbus/${{github.ref_name}}
             for file in *.jar *.pom; do
-              gpg --batch --yes --pinentry-mode loopback --passphrase "${{ secrets.SFIO_PGP_PRIVATE_KEY_PASSPHRASE }}" --armor --detach-sign "$file"
+              gpg --batch --yes --pinentry-mode loopback --local-user "${{ steps.import_gpg.outputs.fingerprint }}" --passphrase "${{ secrets.SFIO_PGP_PRIVATE_KEY_PASSPHRASE }}" --armor --detach-sign "$file"
             done
 
             # Generate checksums

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,10 +472,14 @@ jobs:
       - name: Publish to crates.io
         shell: bash
         run: |
-          # Check if version already exists on crates.io
+          # Authoritative existence check via the sparse index (the same source
+          # cargo reads) so re-running the release is idempotent. Each line is one
+          # published version as compact JSON. This avoids the crates.io web API,
+          # which 403s on default curl User-Agents. If the version is absent we
+          # publish, and any cargo failure is a genuine failure.
           VERSION=${{github.ref_name}}
-          if curl -f -s "https://crates.io/api/v1/crates/rodbus/$VERSION" > /dev/null 2>&1; then
-            echo "✅ rodbus $VERSION already published to crates.io - skipping"
+          if curl -sf "https://index.crates.io/ro/db/rodbus" | grep -qF "\"vers\":\"$VERSION\""; then
+            echo "✅ rodbus $VERSION already on crates.io - skipping"
           else
             echo "Publishing rodbus $VERSION to crates.io..."
             cargo publish -p rodbus --token ${{ secrets.CRATES_PUBLISH_TOKEN }}


### PR DESCRIPTION
Fixes the two remaining blockers preventing a fully green `1.5.0-RC2` release run.

## 1. Maven GPG signing (`release-maven`)

The deploy step failed with `gpg: signing failed: No secret key`, even though the **Import PGP key** step succeeded (`secret keys imported: 1`). Root cause: #177 incidentally bumped `crazy-max/ghaction-import-gpg` from **v3 → v7**. v3 configured a default signing key so a bare `gpg --detach-sign` worked (as in the RC1 release); v7 does not, so with a primary key + subkeys gpg can't auto-select.

**Fix:** add `id: import_gpg` and pass `--local-user ${{ steps.import_gpg.outputs.fingerprint }}` to the signing calls (the action's recommended way to select the key).

(#182 earlier fixed the v7 input rename `gpg-private-key` → `gpg_private_key`, which was the *import* failure; this fixes the *signing* failure that surfaced once import worked.)

## 2. crates.io idempotency (`release-crates-io`)

The job hard-failed running `cargo publish` for a version already on crates.io. The old existence probe queried the crates.io **web API** with curl's default User-Agent, which is rejected (403), so it fell through and published unconditionally.

**Fix:** check the **sparse index** (`index.crates.io`, the same source cargo reads) instead. On a match we skip; otherwise any `cargo publish` failure is a genuine failure — no error-string parsing.

Verified locally against the live index: `1.5.0-RC2` (published) → match → skip; a nonexistent version → no match → publish.

## After merge

Move the `1.5.0-RC2` tag to the merge commit and re-push to re-run. Expected: crates.io skips (already published), NuGet skip-duplicate, Maven signs + uploads, docs re-publish, and `create-github-release` finally runs.