### PR TITLE
ci: bump action-gh-release to v3 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,7 +501,7 @@ jobs:
           cd artifacts/c-bindings
           zip -r ../../release/rodbus-${{github.ref_name}}.zip .
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           draft: true
           files: |


### PR DESCRIPTION
The `create-github-release` job uses `softprops/action-gh-release@v2`, which runs on the deprecated Node 20 runtime (GitHub currently force-runs it on Node 24 and emits a deprecation warning).

`v3.0.0` simply moves the action runtime from Node 20 to Node 24 — no input/API changes — so this is a drop-in bump.

Surfaced by the deprecation warning during the 1.5.0 release run.