### PR TITLE
fix(client): allow shared channel access

### DIFF
--- a/examples/client/src/main.rs
+++ b/examples/client/src/main.rs
@@ -176,7 +176,7 @@ fn print_write_result<T>(result: Result<T, RequestError>) {
     }
 }
 
-async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_channel(channel: Channel) -> Result<(), Box<dyn std::error::Error>> {
     channel.enable().await?;
 
     // ANCHOR: request_param

--- a/examples/perf/src/main.rs
+++ b/examples/perf/src/main.rs
@@ -126,7 +126,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let start = std::time::Instant::now();
 
     // spawn tasks that make requests for the specified duration
-    for (mut channel, params) in channels {
+    for (channel, params) in channels {
         let handle: tokio::task::JoinHandle<Result<usize, RequestError>> =
             tokio::spawn(async move {
                 let mut iterations = 0;

--- a/integration/tests/integration_test.rs
+++ b/integration/tests/integration_test.rs
@@ -132,7 +132,7 @@ async fn test_requests_and_responses() {
     let (tx, mut rx) = tokio::sync::mpsc::channel(8);
     let listener = ClientStateListener { tx };
 
-    let mut channel = spawn_tcp_client_task(
+    let channel = spawn_tcp_client_task(
         HostAddr::ip(addr.ip(), addr.port()),
         10,
         default_retry_strategy(),

--- a/rodbus-client/src/main.rs
+++ b/rodbus-client/src/main.rs
@@ -275,16 +275,16 @@ async fn main() -> Result<(), Error> {
 async fn run() -> Result<(), Error> {
     let cli = Cli::parse();
 
-    let (mut channel, command) = setup_channel(cli.mode).await?;
+    let (channel, command) = setup_channel(cli.mode).await?;
 
     let params = RequestParam::new(UnitId::new(cli.id), REQUEST_TIMEOUT);
 
     match cli.period {
-        None => run_command(&command, &mut channel, params).await,
+        None => run_command(&command, &channel, params).await,
         Some(period_ms) => {
             let period = Duration::from_millis(period_ms);
             loop {
-                run_command(&command, &mut channel, params).await?;
+                run_command(&command, &channel, params).await?;
                 tokio::time::sleep(period).await
             }
         }
@@ -367,7 +367,7 @@ async fn setup_serial(path: String, settings: ModeSerialSettings) -> Result<Chan
 
 async fn run_command(
     command: &Command,
-    channel: &mut Channel,
+    channel: &Channel,
     params: RequestParam,
 ) -> Result<(), Error> {
     match command {

--- a/rodbus/src/client/channel.rs
+++ b/rodbus/src/client/channel.rs
@@ -146,7 +146,7 @@ impl Channel {
 
     /// Read coils from the server
     pub async fn read_coils(
-        &mut self,
+        &self,
         param: RequestParam,
         range: AddressRange,
     ) -> Result<Vec<Indexed<bool>>, RequestError> {
@@ -161,7 +161,7 @@ impl Channel {
 
     /// Read discrete inputs from the server
     pub async fn read_discrete_inputs(
-        &mut self,
+        &self,
         param: RequestParam,
         range: AddressRange,
     ) -> Result<Vec<Indexed<bool>>, RequestError> {
@@ -176,7 +176,7 @@ impl Channel {
 
     /// Read holding registers from the server
     pub async fn read_holding_registers(
-        &mut self,
+        &self,
         param: RequestParam,
         range: AddressRange,
     ) -> Result<Vec<Indexed<u16>>, RequestError> {
@@ -194,7 +194,7 @@ impl Channel {
 
     /// Read input registers from the server
     pub async fn read_input_registers(
-        &mut self,
+        &self,
         param: RequestParam,
         range: AddressRange,
     ) -> Result<Vec<Indexed<u16>>, RequestError> {
@@ -212,7 +212,7 @@ impl Channel {
 
     /// Write a single coil on the server
     pub async fn write_single_coil(
-        &mut self,
+        &self,
         param: RequestParam,
         request: Indexed<bool>,
     ) -> Result<Indexed<bool>, RequestError> {
@@ -227,7 +227,7 @@ impl Channel {
 
     /// Write a single register on the server
     pub async fn write_single_register(
-        &mut self,
+        &self,
         param: RequestParam,
         request: Indexed<u16>,
     ) -> Result<Indexed<u16>, RequestError> {
@@ -242,7 +242,7 @@ impl Channel {
 
     /// Write multiple contiguous coils on the server
     pub async fn write_multiple_coils(
-        &mut self,
+        &self,
         param: RequestParam,
         request: WriteMultiple<bool>,
     ) -> Result<AddressRange, RequestError> {
@@ -260,7 +260,7 @@ impl Channel {
 
     /// Write multiple contiguous registers on the server
     pub async fn write_multiple_registers(
-        &mut self,
+        &self,
         param: RequestParam,
         request: WriteMultiple<u16>,
     ) -> Result<AddressRange, RequestError> {
@@ -277,7 +277,7 @@ impl Channel {
     }
 
     /// Dynamically change the protocol decoding level of the channel
-    pub async fn set_decode_level(&mut self, level: DecodeLevel) -> Result<(), Shutdown> {
+    pub async fn set_decode_level(&self, level: DecodeLevel) -> Result<(), Shutdown> {
         self.tx
             .send(Command::Setting(Setting::DecodeLevel(level)))
             .await?;

--- a/rodbus/src/client/task.rs
+++ b/rodbus/src/client/task.rs
@@ -432,7 +432,7 @@ mod tests {
 
     #[tokio::test]
     async fn returns_io_error_when_write_fails() {
-        let (mut channel, _task, mut io) = spawn_client_loop();
+        let (channel, _task, mut io) = spawn_client_loop();
 
         let error_kind = ErrorKind::ConnectionReset;
 
@@ -452,7 +452,7 @@ mod tests {
 
     #[tokio::test]
     async fn returns_timeout_when_no_response() {
-        let (mut channel, _task, mut io) = spawn_client_loop();
+        let (channel, _task, mut io) = spawn_client_loop();
 
         // the expected request
         let range = AddressRange::try_from(7, 2).unwrap();
@@ -479,7 +479,7 @@ mod tests {
 
     #[tokio::test]
     async fn returns_shutdown_when_task_dropped() {
-        let (mut channel, task, mut io) = spawn_client_loop();
+        let (channel, task, mut io) = spawn_client_loop();
 
         // the expected request
         let range = AddressRange::try_from(7, 2).unwrap();
@@ -517,7 +517,7 @@ mod tests {
 
     #[tokio::test]
     async fn transmit_read_coils_when_requested() {
-        let (mut channel, _task, mut io) = spawn_client_loop();
+        let (channel, _task, mut io) = spawn_client_loop();
 
         let range = AddressRange::try_from(7, 2).unwrap();
         let request = get_framed_adu(FunctionCode::ReadCoils, &range);
@@ -558,7 +558,7 @@ mod tests {
 
         // spawn 3 requests that will all timeout
         for _ in 0..3 {
-            let mut ch = channel.clone();
+            let ch = channel.clone();
             tokio::spawn(async move {
                 ch.read_coils(
                     RequestParam::new(UnitId::new(1), Duration::from_secs(1)),
@@ -588,7 +588,7 @@ mod tests {
 
         // send 10 requests that all timeout
         for _ in 0..10 {
-            let mut ch = channel.clone();
+            let ch = channel.clone();
             tokio::spawn(async move {
                 ch.read_coils(
                     RequestParam::new(UnitId::new(1), Duration::from_secs(1)),
@@ -620,7 +620,7 @@ mod tests {
 
         // First two timeouts
         for _ in 0..2 {
-            let mut ch = channel.clone();
+            let ch = channel.clone();
             tokio::spawn(async move {
                 ch.read_coils(
                     RequestParam::new(UnitId::new(1), Duration::from_secs(1)),
@@ -636,7 +636,7 @@ mod tests {
 
         // Successful request
         let success_task = tokio::spawn({
-            let mut ch = channel.clone();
+            let ch = channel.clone();
             async move {
                 ch.read_coils(
                     RequestParam::new(UnitId::new(1), Duration::from_secs(1)),
@@ -675,7 +675,7 @@ mod tests {
 
         // Two more timeouts - should NOT terminate since counter was reset
         for _ in 0..2 {
-            let mut ch = channel.clone();
+            let ch = channel.clone();
             tokio::spawn(async move {
                 ch.read_coils(
                     RequestParam::new(UnitId::new(1), Duration::from_secs(1)),

--- a/rodbus/src/lib.rs
+++ b/rodbus/src/lib.rs
@@ -15,7 +15,7 @@
 //!#[tokio::main(flavor = "multi_thread")]
 //!async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!
-//!    let mut channel = spawn_tcp_client_task(
+//!    let channel = spawn_tcp_client_task(
 //!        HostAddr::ip("127.0.0.1".parse()?, 502),
 //!        10,
 //!        default_retry_strategy(),


### PR DESCRIPTION
## Summary

Channel's `read`/`write` methods and `set_decode_level` now take `&self` rather than `&mut self`. These methods only build a command and send it on the internal `mpsc::Sender`, so there is nothing to mutate. The existing `enable` and `disable` methods in the same impl already take `&self`.

The deprecated `CallbackSession` is left unchanged.

## Motivation

The exclusive borrow never actually enforced exclusivity. `Channel` is `Clone`, so callers that wanted concurrent requests could simply clone the handle. That behavior is safe by design: each request carries its own `oneshot`, and the client task serializes commands from the shared channel.

What the `&mut self` requirement did enforce was unnecessary friction for shared ownership patterns. In particular, `Arc<Channel>` is awkward to use because `Arc<T>` only provides `&T`. As a result, callers have to clone the channel handle for every operation just to satisfy a borrow requirement that does not reflect the implementation.

## Compatibility

This is source-compatible for normal callers. Existing calls using mutable bindings continue to compile, potentially with an `unused_mut` warning.

The deprecated `CallbackSession` and FFI-facing APIs are unchanged.

`cargo-semver-checks` reports:

```text
223 checks: 223 pass, 31 skip
Summary: no semver update required
```