### PR TITLE
Release rodbus 1.6.0-M2 (crates.io only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.6.0-M2 ###
+* :wrench: Client `Channel` read/write methods and `set_decode_level()` now take `&self` instead of `&mut self`. These methods only send a command on an internal `mpsc::Sender` and mutate nothing, so the exclusive borrow overstated what the API actually requires. This is source-compatible for existing callers. See [#191](https://github.com/stepfunc/rodbus/pull/191).
+
 ### 1.6.0-M1 ###
 * :star: Add non-spawning `create_tcp_server_task()`, `create_rtu_server_task()`, `create_tls_server_task()`, and `create_tls_server_task_with_authz()` that return a `ServerTask` for the caller to spawn, enabling custom task instrumentation. See [#188](https://github.com/stepfunc/rodbus/pull/188).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "example-client"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 dependencies = [
  "rodbus",
  "tokio",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "example-perf"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 dependencies = [
  "clap",
  "rodbus",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "example-server"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 dependencies = [
  "rodbus",
  "tokio",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "integration"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 dependencies = [
  "rodbus",
  "tokio",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "rodbus"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 dependencies = [
  "crc",
  "rx509",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "rodbus-bindings"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 dependencies = [
  "oo-bindgen",
  "rodbus-schema",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "rodbus-client"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 dependencies = [
  "clap",
  "rodbus",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "rodbus-ffi"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "rodbus-ffi-java"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 dependencies = [
  "jni",
  "oo-bindgen",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "rodbus-schema"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 dependencies = [
  "oo-bindgen",
  "sfio-tokio-ffi",

--- a/examples/client/Cargo.toml
+++ b/examples/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-client"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 
 # inherit from workspace
 authors.workspace = true

--- a/examples/perf/Cargo.toml
+++ b/examples/perf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-perf"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 
 # inherit from workspace
 authors.workspace = true

--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-server"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 
 # inherit from workspace
 authors.workspace = true

--- a/ffi/bindings/c/CMakeLists.txt
+++ b/ffi/bindings/c/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(rodbus_c LANGUAGES C CXX)
 
-set(RODBUS_BACKUP_VERSION "1.6.0-M1")
+set(RODBUS_BACKUP_VERSION "1.6.0-M2")
 
 # Determine the architecture
 if(WIN32 AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64" AND CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/ffi/bindings/dotnet/examples/client/client.csproj
+++ b/ffi/bindings/dotnet/examples/client/client.csproj
@@ -14,7 +14,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="rodbus" Version="1.6.0-M1" />
+        <PackageReference Include="rodbus" Version="1.6.0-M2" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/ffi/bindings/dotnet/examples/server/server.csproj
+++ b/ffi/bindings/dotnet/examples/server/server.csproj
@@ -14,7 +14,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="rodbus" Version="1.6.0-M1" />
+        <PackageReference Include="rodbus" Version="1.6.0-M2" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/ffi/bindings/java/examples/pom.xml
+++ b/ffi/bindings/java/examples/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>io.stepfunc</groupId>
             <artifactId>rodbus</artifactId>
-            <version>1.6.0-M1</version>
+            <version>1.6.0-M2</version>
         </dependency>
     </dependencies>
 </project>

--- a/ffi/bindings/java/rodbus-tests/pom.xml
+++ b/ffi/bindings/java/rodbus-tests/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>io.stepfunc</groupId>
             <artifactId>rodbus</artifactId>
-            <version>1.6.0-M1</version>
+            <version>1.6.0-M2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/ffi/rodbus-bindings/Cargo.toml
+++ b/ffi/rodbus-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodbus-bindings"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 description = "application to generate bindings for Rodbus"
 readme = "../README.md"
 

--- a/ffi/rodbus-ffi-java/Cargo.toml
+++ b/ffi/rodbus-ffi-java/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodbus-ffi-java"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 authors = ["Step Function I/O LLC <info@stepfunc.io>"]
 edition = "2021"
 build = "build.rs"

--- a/ffi/rodbus-ffi/Cargo.toml
+++ b/ffi/rodbus-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodbus-ffi"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 authors = ["Step Function I/O LLC <info@stepfunc.io>"]
 edition = "2021"
 description = "FFI for Rodbus"

--- a/ffi/rodbus-schema/Cargo.toml
+++ b/ffi/rodbus-schema/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rodbus-schema"
 # this is the version that all the FFI libraries get, since it's in their schema
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 description = "oobindgen schema for Rodbus"
 readme = "../README.md"
 

--- a/guide/sitedata.json
+++ b/guide/sitedata.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.6.0-M1",
+    "version": "1.6.0-M2",
     "github_url": "https://github.com/stepfunc/rodbus"
 }

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 autobins = false
 autotests = false
 autobenches = false

--- a/rodbus-client/Cargo.toml
+++ b/rodbus-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodbus-client"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 description = "A command line program for making Modbus client requests using the Rodbus crate"
 readme = "README.md"
 

--- a/rodbus/Cargo.toml
+++ b/rodbus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodbus"
-version = "1.6.0-M1"
+version = "1.6.0-M2"
 description = "A high-performance async implementation of the Modbus protocol using tokio"
 readme = "README.md"
 


### PR DESCRIPTION
Milestone release for #191. No FFI changes, so this is not pushed to Maven/NuGet/docs.

Lockstep version bump across all crates, FFI binding build files, and the guide. The lockstep bump is required even for a crates.io-only publish: `rodbus-schema` asserts the bindings' expected version against `rodbus::VERSION`, so bumping `rodbus` alone fails the binding tests.

After merge, publish manually from `main` with `cargo publish -p rodbus`. No tag is pushed — a tag would fire the full release pipeline across every ecosystem.