### PR TITLE
Feat/client explicit shutdown

### DIFF
--- a/examples/client/src/main.rs
+++ b/examples/client/src/main.rs
@@ -176,7 +176,7 @@ fn print_write_result<T>(result: Result<T, RequestError>) {
     }
 }
 
-async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_channel(channel: Channel) -> Result<(), Box<dyn std::error::Error>> {
     channel.enable().await?;
 
     // ANCHOR: request_param

--- a/examples/perf/src/main.rs
+++ b/examples/perf/src/main.rs
@@ -126,7 +126,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let start = std::time::Instant::now();
 
     // spawn tasks that make requests for the specified duration
-    for (mut channel, params) in channels {
+    for (channel, params) in channels {
         let handle: tokio::task::JoinHandle<Result<usize, RequestError>> =
             tokio::spawn(async move {
                 let mut iterations = 0;

--- a/integration/tests/integration_test.rs
+++ b/integration/tests/integration_test.rs
@@ -132,7 +132,7 @@ async fn test_requests_and_responses() {
     let (tx, mut rx) = tokio::sync::mpsc::channel(8);
     let listener = ClientStateListener { tx };
 
-    let mut channel = spawn_tcp_client_task(
+    let channel = spawn_tcp_client_task(
         HostAddr::ip(addr.ip(), addr.port()),
         10,
         default_retry_strategy(),

--- a/rodbus-client/src/main.rs
+++ b/rodbus-client/src/main.rs
@@ -275,16 +275,16 @@ async fn main() -> Result<(), Error> {
 async fn run() -> Result<(), Error> {
     let cli = Cli::parse();
 
-    let (mut channel, command) = setup_channel(cli.mode).await?;
+    let (channel, command) = setup_channel(cli.mode).await?;
 
     let params = RequestParam::new(UnitId::new(cli.id), REQUEST_TIMEOUT);
 
     match cli.period {
-        None => run_command(&command, &mut channel, params).await,
+        None => run_command(&command, &channel, params).await,
         Some(period_ms) => {
             let period = Duration::from_millis(period_ms);
             loop {
-                run_command(&command, &mut channel, params).await?;
+                run_command(&command, &channel, params).await?;
                 tokio::time::sleep(period).await
             }
         }
@@ -367,7 +367,7 @@ async fn setup_serial(path: String, settings: ModeSerialSettings) -> Result<Chan
 
 async fn run_command(
     command: &Command,
-    channel: &mut Channel,
+    channel: &Channel,
     params: RequestParam,
 ) -> Result<(), Error> {
     match command {

--- a/rodbus/src/client/channel.rs
+++ b/rodbus/src/client/channel.rs
@@ -146,7 +146,7 @@ impl Channel {
 
     /// Read coils from the server
     pub async fn read_coils(
-        &mut self,
+        &self,
         param: RequestParam,
         range: AddressRange,
     ) -> Result<Vec<Indexed<bool>>, RequestError> {
@@ -161,7 +161,7 @@ impl Channel {
 
     /// Read discrete inputs from the server
     pub async fn read_discrete_inputs(
-        &mut self,
+        &self,
         param: RequestParam,
         range: AddressRange,
     ) -> Result<Vec<Indexed<bool>>, RequestError> {
@@ -176,7 +176,7 @@ impl Channel {
 
     /// Read holding registers from the server
     pub async fn read_holding_registers(
-        &mut self,
+        &self,
         param: RequestParam,
         range: AddressRange,
     ) -> Result<Vec<Indexed<u16>>, RequestError> {
@@ -194,7 +194,7 @@ impl Channel {
 
     /// Read input registers from the server
     pub async fn read_input_registers(
-        &mut self,
+        &self,
         param: RequestParam,
         range: AddressRange,
     ) -> Result<Vec<Indexed<u16>>, RequestError> {
@@ -212,7 +212,7 @@ impl Channel {
 
     /// Write a single coil on the server
     pub async fn write_single_coil(
-        &mut self,
+        &self,
         param: RequestParam,
         request: Indexed<bool>,
     ) -> Result<Indexed<bool>, RequestError> {
@@ -227,7 +227,7 @@ impl Channel {
 
     /// Write a single register on the server
     pub async fn write_single_register(
-        &mut self,
+        &self,
         param: RequestParam,
         request: Indexed<u16>,
     ) -> Result<Indexed<u16>, RequestError> {
@@ -242,7 +242,7 @@ impl Channel {
 
     /// Write multiple contiguous coils on the server
     pub async fn write_multiple_coils(
-        &mut self,
+        &self,
         param: RequestParam,
         request: WriteMultiple<bool>,
     ) -> Result<AddressRange, RequestError> {
@@ -260,7 +260,7 @@ impl Channel {
 
     /// Write multiple contiguous registers on the server
     pub async fn write_multiple_registers(
-        &mut self,
+        &self,
         param: RequestParam,
         request: WriteMultiple<u16>,
     ) -> Result<AddressRange, RequestError> {
@@ -277,7 +277,7 @@ impl Channel {
     }
 
     /// Dynamically change the protocol decoding level of the channel
-    pub async fn set_decode_level(&mut self, level: DecodeLevel) -> Result<(), Shutdown> {
+    pub async fn set_decode_level(&self, level: DecodeLevel) -> Result<(), Shutdown> {
         self.tx
             .send(Command::Setting(Setting::DecodeLevel(level)))
             .await?;

--- a/rodbus/src/client/channel.rs
+++ b/rodbus/src/client/channel.rs
@@ -19,7 +19,8 @@ pub struct Channel {
 ///
 /// This is returned, alongside its [`Channel`] handle, by the `create_*_client_task` functions.
 /// Drive it to completion by awaiting [`ClientTask::run`], typically from within
-/// [`tokio::spawn`]. The task completes when the associated [`Channel`] handle is dropped.
+/// [`tokio::spawn`]. The task completes when every associated [`Channel`] handle is dropped or
+/// [`Channel::shutdown`] is called.
 ///
 /// Unlike the `spawn_*_client_task` functions, no tracing span is attached to the task, so the
 /// caller is free to wrap [`run`](ClientTask::run) with their own instrumentation.
@@ -47,7 +48,7 @@ impl ClientTask {
         }
     }
 
-    /// Run the channel task until the associated [`Channel`] handle is dropped.
+    /// Run the channel task until every [`Channel`] is dropped or [`Channel::shutdown`] is called.
     pub async fn run(self) {
         match self.inner {
             ClientTaskInner::Tcp(mut task) => {
@@ -141,6 +142,22 @@ impl Channel {
     /// Disable communications
     pub async fn disable(&self) -> Result<(), Shutdown> {
         self.tx.send(Command::Setting(Setting::Disable)).await?;
+        Ok(())
+    }
+
+    /// Terminate the channel task, however many [`Channel`] handles remain
+    ///
+    /// The task also terminates once every handle is dropped. This is for callers that cannot
+    /// guarantee that, such as one publishing a handle where it will outlive the task.
+    ///
+    /// The command is queued behind any pending requests, and a transaction already in flight
+    /// runs to completion, so the task ends within one response timeout of the last of them.
+    /// Requests made after this fail with [`RequestError::Shutdown`].
+    ///
+    /// This signals the task rather than waiting on it. Await [`ClientTask::run`] to observe it
+    /// finish. `Err(Shutdown)` means the task had already terminated.
+    pub async fn shutdown(&self) -> Result<(), Shutdown> {
+        self.tx.send(Command::Shutdown).await?;
         Ok(())
     }
 

--- a/rodbus/src/client/message.rs
+++ b/rodbus/src/client/message.rs
@@ -27,6 +27,10 @@ pub(crate) enum Command {
     Request(Request),
     /// Change a setting
     Setting(Setting),
+    /// Terminate the channel task
+    ///
+    /// Queued like any other command, so anything ahead of it is processed first
+    Shutdown,
 }
 
 pub(crate) struct Request {

--- a/rodbus/src/client/task.rs
+++ b/rodbus/src/client/task.rs
@@ -432,7 +432,7 @@ mod tests {
 
     #[tokio::test]
     async fn returns_io_error_when_write_fails() {
-        let (mut channel, _task, mut io) = spawn_client_loop();
+        let (channel, _task, mut io) = spawn_client_loop();
 
         let error_kind = ErrorKind::ConnectionReset;
 
@@ -452,7 +452,7 @@ mod tests {
 
     #[tokio::test]
     async fn returns_timeout_when_no_response() {
-        let (mut channel, _task, mut io) = spawn_client_loop();
+        let (channel, _task, mut io) = spawn_client_loop();
 
         // the expected request
         let range = AddressRange::try_from(7, 2).unwrap();
@@ -479,7 +479,7 @@ mod tests {
 
     #[tokio::test]
     async fn returns_shutdown_when_task_dropped() {
-        let (mut channel, task, mut io) = spawn_client_loop();
+        let (channel, task, mut io) = spawn_client_loop();
 
         // the expected request
         let range = AddressRange::try_from(7, 2).unwrap();
@@ -517,7 +517,7 @@ mod tests {
 
     #[tokio::test]
     async fn transmit_read_coils_when_requested() {
-        let (mut channel, _task, mut io) = spawn_client_loop();
+        let (channel, _task, mut io) = spawn_client_loop();
 
         let range = AddressRange::try_from(7, 2).unwrap();
         let request = get_framed_adu(FunctionCode::ReadCoils, &range);
@@ -558,7 +558,7 @@ mod tests {
 
         // spawn 3 requests that will all timeout
         for _ in 0..3 {
-            let mut ch = channel.clone();
+            let ch = channel.clone();
             tokio::spawn(async move {
                 ch.read_coils(
                     RequestParam::new(UnitId::new(1), Duration::from_secs(1)),
@@ -588,7 +588,7 @@ mod tests {
 
         // send 10 requests that all timeout
         for _ in 0..10 {
-            let mut ch = channel.clone();
+            let ch = channel.clone();
             tokio::spawn(async move {
                 ch.read_coils(
                     RequestParam::new(UnitId::new(1), Duration::from_secs(1)),
@@ -620,7 +620,7 @@ mod tests {
 
         // First two timeouts
         for _ in 0..2 {
-            let mut ch = channel.clone();
+            let ch = channel.clone();
             tokio::spawn(async move {
                 ch.read_coils(
                     RequestParam::new(UnitId::new(1), Duration::from_secs(1)),
@@ -636,7 +636,7 @@ mod tests {
 
         // Successful request
         let success_task = tokio::spawn({
-            let mut ch = channel.clone();
+            let ch = channel.clone();
             async move {
                 ch.read_coils(
                     RequestParam::new(UnitId::new(1), Duration::from_secs(1)),
@@ -675,7 +675,7 @@ mod tests {
 
         // Two more timeouts - should NOT terminate since counter was reset
         for _ in 0..2 {
-            let mut ch = channel.clone();
+            let ch = channel.clone();
             tokio::spawn(async move {
                 ch.read_coils(
                     RequestParam::new(UnitId::new(1), Duration::from_secs(1)),

--- a/rodbus/src/client/task.rs
+++ b/rodbus/src/client/task.rs
@@ -168,6 +168,7 @@ impl ClientLoop {
                 Ok(())
             }
             Command::Request(mut request) => self.run_one_request(io, &mut request).await,
+            Command::Shutdown => Err(SessionError::Shutdown),
         }
     }
 
@@ -336,6 +337,7 @@ impl ClientLoop {
                     Err(StateChange::Disable)
                 }
             }
+            Command::Shutdown => Err(StateChange::Shutdown),
         }
     }
 
@@ -428,6 +430,83 @@ mod tests {
         let (channel, task, _io) = spawn_client_loop();
         drop(channel);
         assert_eq!(task.await.unwrap(), SessionError::Shutdown);
+    }
+
+    #[tokio::test]
+    async fn task_completes_when_shutdown_requested_with_a_handle_still_alive() {
+        let (channel, task, _io) = spawn_client_loop();
+
+        channel.shutdown().await.unwrap();
+        assert_eq!(task.await.unwrap(), SessionError::Shutdown);
+
+        // the handle outlived the task it terminated, and now reports that it is gone
+        assert!(channel.shutdown().await.is_err());
+        let res = channel
+            .read_coils(
+                RequestParam::new(UnitId::new(1), Duration::from_secs(1)),
+                AddressRange::try_from(7, 2).unwrap(),
+            )
+            .await;
+        assert_eq!(res, Err(RequestError::Shutdown));
+    }
+
+    #[tokio::test]
+    async fn transaction_in_flight_completes_before_requested_shutdown() {
+        let (channel, task, mut io) = spawn_client_loop();
+        let other_handle = channel.clone();
+
+        let range = AddressRange::try_from(7, 2).unwrap();
+        let request = get_framed_adu(FunctionCode::ReadCoils, &range);
+        let response = get_framed_adu(
+            FunctionCode::ReadCoils,
+            &BitWriter::new(ReadBitsRange { inner: range }, |idx| match idx {
+                7 => Ok(true),
+                8 => Ok(false),
+                _ => Err(ExceptionCode::IllegalDataAddress),
+            }),
+        );
+
+        let coils = tokio::spawn(async move {
+            channel
+                .read_coils(
+                    RequestParam::new(UnitId::new(1), Duration::from_secs(1)),
+                    range,
+                )
+                .await
+        });
+
+        // the request is on the wire, so the loop is inside a transaction
+        assert_eq!(io.next_event().await, Event::Write(request));
+
+        // shutdown queues behind that transaction rather than interrupting it
+        other_handle.shutdown().await.unwrap();
+        io.read(&response);
+
+        assert_eq!(
+            coils.await.unwrap().unwrap(),
+            vec![Indexed::new(7, true), Indexed::new(8, false)]
+        );
+        assert_eq!(task.await.unwrap(), SessionError::Shutdown);
+    }
+
+    #[tokio::test]
+    async fn shutdown_ends_the_task_while_it_is_failing_requests() {
+        // fail_requests() is the path taken while disconnected or waiting to retry, which reads
+        // the queue separately from the session loop and so needs its own handling
+        let (tx, rx) = tokio::sync::mpsc::channel(16);
+        let mut client_loop = ClientLoop::new(
+            rx.into(),
+            FrameWriter::tcp(),
+            FramedReader::tcp(),
+            DecodeLevel::nothing(),
+            None,
+        );
+        let channel = Channel { tx };
+
+        let task = tokio::spawn(async move { client_loop.fail_requests().await });
+        channel.shutdown().await.unwrap();
+
+        assert_eq!(task.await.unwrap(), StateChange::Shutdown);
     }
 
     #[tokio::test]

--- a/rodbus/src/lib.rs
+++ b/rodbus/src/lib.rs
@@ -15,7 +15,7 @@
 //!#[tokio::main(flavor = "multi_thread")]
 //!async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!
-//!    let mut channel = spawn_tcp_client_task(
+//!    let channel = spawn_tcp_client_task(
 //!        HostAddr::ip("127.0.0.1".parse()?, 502),
 //!        10,
 //!        default_retry_strategy(),


### PR DESCRIPTION
## Problem

The client task completes only when every `Channel` clone has been dropped:
`Receiver::recv()` returns `None` once the last sender goes away, which becomes
`SessionError::Shutdown`.

That makes termination depend on how many handles exist and where they are held.
A caller that publishes a `Channel` somewhere outliving the task — a service
registry, a shared cache, anything with process lifetime — can never terminate
it, and awaiting the task's `JoinHandle` hangs.

Dropping handles in the right order is a convention every holder has to honour,
and nothing in the type system enforces it.

## Change

Adds `Channel::shutdown()`, which sends shutdown as a command rather than
signalling it by releasing the last handle:

```rust
pub async fn shutdown(&self) -> Result<(), Shutdown>
```

Drop-based termination is unchanged, so this is additive — existing callers need
no changes.

Command gains a Shutdown variant, handled at both points where
reads its queue:

- run_cmd, while connected, returning SessionError::Shutdown
- fail_next_request, while disconnected or waiting to retry, r
StateChange::Shutdown

Both already existed for the drop case, so this reuses the wind-down path rather
than adding a second one. Handling only the first would leave
solely while the device is reachable.

## Semantics

- Queued behind pending requests, so anything already in the queue is still
processed — matching what dropping every handle does, since an
buffer before reporting closure.
- A transaction already in flight runs to completion, so the t
within one response timeout of the last queued request.
- Requests made after shutdown fail with RequestError::Shutdow
- Signals the task rather than waiting on it; await ClientTask::run to observe
completion.
- Returns Err(Shutdown) if the task has already terminated, so a second call is
harmless.

TCP and serial share ClientLoop, so both are covered with no
channel task.