### PR TITLE
feat(client): add Channel::shutdown() to terminate the task explicitly

### DIFF
--- a/rodbus/src/client/channel.rs
+++ b/rodbus/src/client/channel.rs
@@ -19,7 +19,8 @@ pub struct Channel {
 ///
 /// This is returned, alongside its [`Channel`] handle, by the `create_*_client_task` functions.
 /// Drive it to completion by awaiting [`ClientTask::run`], typically from within
-/// [`tokio::spawn`]. The task completes when the associated [`Channel`] handle is dropped.
+/// [`tokio::spawn`]. The task completes when every associated [`Channel`] handle is dropped or
+/// [`Channel::shutdown`] is called.
 ///
 /// Unlike the `spawn_*_client_task` functions, no tracing span is attached to the task, so the
 /// caller is free to wrap [`run`](ClientTask::run) with their own instrumentation.
@@ -47,7 +48,7 @@ impl ClientTask {
         }
     }
 
-    /// Run the channel task until the associated [`Channel`] handle is dropped.
+    /// Run the channel task until every [`Channel`] is dropped or [`Channel::shutdown`] is called.
     pub async fn run(self) {
         match self.inner {
             ClientTaskInner::Tcp(mut task) => {
@@ -141,6 +142,22 @@ impl Channel {
     /// Disable communications
     pub async fn disable(&self) -> Result<(), Shutdown> {
         self.tx.send(Command::Setting(Setting::Disable)).await?;
+        Ok(())
+    }
+
+    /// Terminate the channel task, however many [`Channel`] handles remain
+    ///
+    /// The task also terminates once every handle is dropped. This is for callers that cannot
+    /// guarantee that, such as one publishing a handle where it will outlive the task.
+    ///
+    /// The command is queued behind any pending requests, and a transaction already in flight
+    /// runs to completion, so the task ends within one response timeout of the last of them.
+    /// Requests made after this fail with [`RequestError::Shutdown`].
+    ///
+    /// This signals the task rather than waiting on it. Await [`ClientTask::run`] to observe it
+    /// finish. `Err(Shutdown)` means the task had already terminated.
+    pub async fn shutdown(&self) -> Result<(), Shutdown> {
+        self.tx.send(Command::Shutdown).await?;
         Ok(())
     }
 

--- a/rodbus/src/client/channel.rs
+++ b/rodbus/src/client/channel.rs
@@ -9,8 +9,8 @@ use crate::error::*;
 use crate::types::{AddressRange, BitIterator, Indexed, RegisterIterator, UnitId};
 use crate::DecodeLevel;
 
-/// Async channel used to make requests. The task is shutdown when every handle is dropped or
-/// [`Channel::shutdown`] is called.
+/// Async channel used to make requests. The associated task is shutdown when every handle is
+/// dropped or [`Channel::shutdown`] is called.
 #[derive(Debug, Clone)]
 pub struct Channel {
     pub(crate) tx: tokio::sync::mpsc::Sender<Command>,
@@ -147,7 +147,9 @@ impl Channel {
         Ok(())
     }
 
-    /// Shut down the channel task, even if one or more [`Channel`] handles are still alive
+    /// Begin shutting down the channel task, even if one or more [`Channel`] handles are still alive
+    ///
+    /// The task completes when it processes the command, which may be after this returns
     pub async fn shutdown(&self) -> Result<(), Shutdown> {
         self.tx.send(Command::Shutdown).await?;
         Ok(())

--- a/rodbus/src/client/channel.rs
+++ b/rodbus/src/client/channel.rs
@@ -9,7 +9,8 @@ use crate::error::*;
 use crate::types::{AddressRange, BitIterator, Indexed, RegisterIterator, UnitId};
 use crate::DecodeLevel;
 
-/// Async channel used to make requests
+/// Async channel used to make requests. The task is shutdown when every handle is dropped or
+/// [`Channel::shutdown`] is called.
 #[derive(Debug, Clone)]
 pub struct Channel {
     pub(crate) tx: tokio::sync::mpsc::Sender<Command>,
@@ -48,7 +49,8 @@ impl ClientTask {
         }
     }
 
-    /// Run the channel task until every [`Channel`] is dropped or [`Channel::shutdown`] is called.
+    /// Run the channel task until every [`Channel`] handle is dropped or [`Channel::shutdown`] is
+    /// called.
     pub async fn run(self) {
         match self.inner {
             ClientTaskInner::Tcp(mut task) => {
@@ -145,17 +147,7 @@ impl Channel {
         Ok(())
     }
 
-    /// Terminate the channel task, however many [`Channel`] handles remain
-    ///
-    /// The task also terminates once every handle is dropped. This is for callers that cannot
-    /// guarantee that, such as one publishing a handle where it will outlive the task.
-    ///
-    /// The command is queued behind any pending requests, and a transaction already in flight
-    /// runs to completion, so the task ends within one response timeout of the last of them.
-    /// Requests made after this fail with [`RequestError::Shutdown`].
-    ///
-    /// This signals the task rather than waiting on it. Await [`ClientTask::run`] to observe it
-    /// finish. `Err(Shutdown)` means the task had already terminated.
+    /// Shut down the channel task, even if one or more [`Channel`] handles are still alive
     pub async fn shutdown(&self) -> Result<(), Shutdown> {
         self.tx.send(Command::Shutdown).await?;
         Ok(())

--- a/rodbus/src/client/message.rs
+++ b/rodbus/src/client/message.rs
@@ -27,6 +27,10 @@ pub(crate) enum Command {
     Request(Request),
     /// Change a setting
     Setting(Setting),
+    /// Terminate the channel task
+    ///
+    /// Queued like any other command, so anything ahead of it is processed first
+    Shutdown,
 }
 
 pub(crate) struct Request {

--- a/rodbus/src/client/message.rs
+++ b/rodbus/src/client/message.rs
@@ -27,9 +27,7 @@ pub(crate) enum Command {
     Request(Request),
     /// Change a setting
     Setting(Setting),
-    /// Terminate the channel task
-    ///
-    /// Queued like any other command, so anything ahead of it is processed first
+    /// Shut down the channel task
     Shutdown,
 }
 

--- a/rodbus/src/client/mod.rs
+++ b/rodbus/src/client/mod.rs
@@ -89,7 +89,8 @@ impl HostAddr {
 }
 
 /// Spawns a channel task onto the runtime that maintains a TCP connection and processes
-/// requests. The task completes when the returned channel handle is dropped.
+/// requests. The task completes when the returned channel handle is dropped or
+/// [`Channel::shutdown`] is called.
 ///
 /// The channel uses the provided [`RetryStrategy`] to pause between failed connection attempts
 ///
@@ -119,7 +120,8 @@ pub fn spawn_tcp_client_task(
 }
 
 /// Spawns a channel task onto the runtime that maintains a TCP connection and processes
-/// requests. The task completes when the returned channel handle is dropped.
+/// requests. The task completes when the returned channel handle is dropped or
+/// [`Channel::shutdown`] is called.
 ///
 /// The channel uses the provided [`RetryStrategy`] to pause between failed connection attempts
 ///
@@ -146,7 +148,7 @@ pub fn spawn_tcp_client_task_with_options(
 /// Creates a channel task that maintains a TCP connection and processes requests, but does
 /// **not** spawn it. It is the caller's responsibility to run the returned [`ClientTask`] onto a
 /// runtime, e.g. `tokio::spawn(task.run())`. The task completes when the returned [`Channel`]
-/// handle is dropped.
+/// handle is dropped or [`Channel::shutdown`] is called.
 ///
 /// Unlike [`spawn_tcp_client_task_with_options`], no tracing span is attached to the task, so the
 /// caller may wrap [`ClientTask::run`] with their own instrumentation before spawning it.
@@ -172,8 +174,8 @@ pub fn create_tcp_client_task_with_options(
 }
 
 /// Spawns a channel task onto the runtime that opens a serial port and processes
-/// requests. The task completes when the returned channel handle
-/// is dropped.
+/// requests. The task completes when the returned channel handle is dropped or
+/// [`Channel::shutdown`] is called.
 ///
 /// The channel uses the provided [`RetryStrategy`] to pause between failed attempts to open the
 /// serial port or after the serial port fails.
@@ -208,7 +210,7 @@ pub fn spawn_rtu_client_task(
 /// Creates a channel task that opens a serial port and processes requests, but does **not**
 /// spawn it. It is the caller's responsibility to run the returned [`ClientTask`] onto a runtime,
 /// e.g. `tokio::spawn(task.run())`. The task completes when the returned [`Channel`] handle is
-/// dropped.
+/// dropped or [`Channel::shutdown`] is called.
 ///
 /// Unlike [`spawn_rtu_client_task`], no tracing span is attached to the task, so the caller may
 /// wrap [`ClientTask::run`] with their own instrumentation before spawning it.
@@ -242,8 +244,8 @@ pub fn create_rtu_client_task(
 }
 
 /// Spawns a channel task onto the runtime that maintains a TLS connection and processes
-/// requests. The task completes when the returned channel handle
-/// is dropped.
+/// requests. The task completes when the returned channel handle is dropped or
+/// [`Channel::shutdown`] is called.
 ///
 /// The channel uses the provided [`RetryStrategy`] to pause between failed connection attempts
 ///
@@ -280,7 +282,7 @@ pub fn spawn_tls_client_task(
 /// Creates a channel task that maintains a TLS connection and processes requests, but does
 /// **not** spawn it. It is the caller's responsibility to run the returned [`ClientTask`] onto a
 /// runtime, e.g. `tokio::spawn(task.run())`. The task completes when the returned [`Channel`]
-/// handle is dropped.
+/// handle is dropped or [`Channel::shutdown`] is called.
 ///
 /// Unlike [`spawn_tls_client_task`], no tracing span is attached to the task, so the caller may
 /// wrap [`ClientTask::run`] with their own instrumentation before spawning it.

--- a/rodbus/src/client/task.rs
+++ b/rodbus/src/client/task.rs
@@ -440,7 +440,7 @@ mod tests {
         assert_eq!(task.await.unwrap(), SessionError::Shutdown);
 
         // the handle outlived the task it terminated, and now reports that it is gone
-        assert!(channel.shutdown().await.is_err());
+        assert_eq!(channel.shutdown().await, Err(Shutdown));
         let res = channel
             .read_coils(
                 RequestParam::new(UnitId::new(1), Duration::from_secs(1)),

--- a/rodbus/src/client/task.rs
+++ b/rodbus/src/client/task.rs
@@ -168,6 +168,7 @@ impl ClientLoop {
                 Ok(())
             }
             Command::Request(mut request) => self.run_one_request(io, &mut request).await,
+            Command::Shutdown => Err(SessionError::Shutdown),
         }
     }
 
@@ -336,6 +337,7 @@ impl ClientLoop {
                     Err(StateChange::Disable)
                 }
             }
+            Command::Shutdown => Err(StateChange::Shutdown),
         }
     }
 
@@ -428,6 +430,83 @@ mod tests {
         let (channel, task, _io) = spawn_client_loop();
         drop(channel);
         assert_eq!(task.await.unwrap(), SessionError::Shutdown);
+    }
+
+    #[tokio::test]
+    async fn task_completes_when_shutdown_requested_with_a_handle_still_alive() {
+        let (channel, task, _io) = spawn_client_loop();
+
+        channel.shutdown().await.unwrap();
+        assert_eq!(task.await.unwrap(), SessionError::Shutdown);
+
+        // the handle outlived the task it terminated, and now reports that it is gone
+        assert!(channel.shutdown().await.is_err());
+        let res = channel
+            .read_coils(
+                RequestParam::new(UnitId::new(1), Duration::from_secs(1)),
+                AddressRange::try_from(7, 2).unwrap(),
+            )
+            .await;
+        assert_eq!(res, Err(RequestError::Shutdown));
+    }
+
+    #[tokio::test]
+    async fn transaction_in_flight_completes_before_requested_shutdown() {
+        let (channel, task, mut io) = spawn_client_loop();
+        let other_handle = channel.clone();
+
+        let range = AddressRange::try_from(7, 2).unwrap();
+        let request = get_framed_adu(FunctionCode::ReadCoils, &range);
+        let response = get_framed_adu(
+            FunctionCode::ReadCoils,
+            &BitWriter::new(ReadBitsRange { inner: range }, |idx| match idx {
+                7 => Ok(true),
+                8 => Ok(false),
+                _ => Err(ExceptionCode::IllegalDataAddress),
+            }),
+        );
+
+        let coils = tokio::spawn(async move {
+            channel
+                .read_coils(
+                    RequestParam::new(UnitId::new(1), Duration::from_secs(1)),
+                    range,
+                )
+                .await
+        });
+
+        // the request is on the wire, so the loop is inside a transaction
+        assert_eq!(io.next_event().await, Event::Write(request));
+
+        // shutdown queues behind that transaction rather than interrupting it
+        other_handle.shutdown().await.unwrap();
+        io.read(&response);
+
+        assert_eq!(
+            coils.await.unwrap().unwrap(),
+            vec![Indexed::new(7, true), Indexed::new(8, false)]
+        );
+        assert_eq!(task.await.unwrap(), SessionError::Shutdown);
+    }
+
+    #[tokio::test]
+    async fn shutdown_ends_the_task_while_it_is_failing_requests() {
+        // fail_requests() is the path taken while disconnected or waiting to retry, which reads
+        // the queue separately from the session loop and so needs its own handling
+        let (tx, rx) = tokio::sync::mpsc::channel(16);
+        let mut client_loop = ClientLoop::new(
+            rx.into(),
+            FrameWriter::tcp(),
+            FramedReader::tcp(),
+            DecodeLevel::nothing(),
+            None,
+        );
+        let channel = Channel { tx };
+
+        let task = tokio::spawn(async move { client_loop.fail_requests().await });
+        channel.shutdown().await.unwrap();
+
+        assert_eq!(task.await.unwrap(), StateChange::Shutdown);
     }
 
     #[tokio::test]

--- a/rodbus/src/error.rs
+++ b/rodbus/src/error.rs
@@ -1,7 +1,7 @@
 use scursor::WriteError;
 
 /// The task processing requests has terminated
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Shutdown;
 
 impl std::error::Error for Shutdown {}

--- a/rodbus/src/server/mod.rs
+++ b/rodbus/src/server/mod.rs
@@ -99,16 +99,7 @@ impl ServerHandle {
         Ok(())
     }
 
-    /// Terminate the server task, even if this [`ServerHandle`] is still alive
-    ///
-    /// The task also terminates once the handle is dropped. This is for callers that cannot
-    /// guarantee that, such as one publishing a handle where it will outlive the task.
-    ///
-    /// The command is queued behind any pending settings, so those are applied first. Active
-    /// sessions end as the task unwinds, the same as when the handle is dropped.
-    ///
-    /// This signals the task rather than waiting on it. Await [`ServerTask::run`] to observe it
-    /// finish. `Err(Shutdown)` means the task had already terminated.
+    /// Shut down the server task, even if this [`ServerHandle`] is still alive
     pub async fn shutdown(&self) -> Result<(), Shutdown> {
         self.tx.send(ServerSetting::Shutdown).await?;
         Ok(())

--- a/rodbus/src/server/mod.rs
+++ b/rodbus/src/server/mod.rs
@@ -29,7 +29,8 @@ pub use crate::tcp::tls::server::TlsServerConfig;
 #[cfg(feature = "enable-tls")]
 pub use crate::tcp::tls::*;
 
-/// Handle to the server async task. The task is shutdown when the handle is dropped.
+/// Handle to the server async task. The task is shutdown when the handle is dropped or
+/// [`ServerHandle::shutdown`] is called.
 #[derive(Debug)]
 pub struct ServerHandle {
     tx: tokio::sync::mpsc::Sender<ServerSetting>,
@@ -39,7 +40,8 @@ pub struct ServerHandle {
 ///
 /// This is returned, alongside its [`ServerHandle`], by the `create_*_server_task` functions.
 /// Drive it to completion by awaiting [`ServerTask::run`], typically from within
-/// [`tokio::spawn`]. The task completes when the associated [`ServerHandle`] is dropped.
+/// [`tokio::spawn`]. The task completes when the associated [`ServerHandle`] is dropped or
+/// [`ServerHandle::shutdown`] is called.
 ///
 /// Unlike the `spawn_*_server_task` functions, no tracing span is attached to the task, so the
 /// caller is free to wrap [`run`](ServerTask::run) with their own instrumentation.
@@ -70,7 +72,8 @@ impl<T: RequestHandler> ServerTask<T> {
         }
     }
 
-    /// Run the server task until the associated [`ServerHandle`] is dropped.
+    /// Run the server task until the [`ServerHandle`] is dropped or
+    /// [`ServerHandle::shutdown`] is called.
     pub async fn run(self) {
         match self.inner {
             ServerTaskInner::Tcp(mut task, commands) => task.run(commands).await,
@@ -93,6 +96,21 @@ impl ServerHandle {
     /// Change the decoding level for future sessions and all active sessions
     pub async fn set_decode_level(&mut self, level: DecodeLevel) -> Result<(), Shutdown> {
         self.tx.send(ServerSetting::ChangeDecoding(level)).await?;
+        Ok(())
+    }
+
+    /// Terminate the server task, even if this [`ServerHandle`] is still alive
+    ///
+    /// The task also terminates once the handle is dropped. This is for callers that cannot
+    /// guarantee that, such as one publishing a handle where it will outlive the task.
+    ///
+    /// The command is queued behind any pending settings, so those are applied first. Active
+    /// sessions end as the task unwinds, the same as when the handle is dropped.
+    ///
+    /// This signals the task rather than waiting on it. Await [`ServerTask::run`] to observe it
+    /// finish. `Err(Shutdown)` means the task had already terminated.
+    pub async fn shutdown(&self) -> Result<(), Shutdown> {
+        self.tx.send(ServerSetting::Shutdown).await?;
         Ok(())
     }
 }

--- a/rodbus/src/server/mod.rs
+++ b/rodbus/src/server/mod.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use tracing::Instrument;
 
 use crate::decode::DecodeLevel;
-use crate::server::task::ServerSetting;
+use crate::server::task::ServerCommand;
 use crate::tcp::server::{ServerTask as TcpServerTask, TcpServerConnectionHandler};
 
 /// server handling
@@ -14,8 +14,8 @@ pub(crate) mod response;
 pub(crate) mod task;
 pub(crate) mod types;
 
-/// Fine for this to be a constant since the corresponding channel is only used to change settings
-pub(crate) const SERVER_SETTING_CHANNEL_CAPACITY: usize = 8;
+/// Fine for this to be a constant since the corresponding channel is only used for commands
+pub(crate) const SERVER_COMMAND_CHANNEL_CAPACITY: usize = 8;
 
 use crate::error::Shutdown;
 
@@ -29,18 +29,18 @@ pub use crate::tcp::tls::server::TlsServerConfig;
 #[cfg(feature = "enable-tls")]
 pub use crate::tcp::tls::*;
 
-/// Handle to the server async task. The task is shutdown when the handle is dropped or
-/// [`ServerHandle::shutdown`] is called.
+/// Handle to the server async task. The associated task is shutdown when every handle is dropped
+/// or [`ServerHandle::shutdown`] is called.
 #[derive(Debug)]
 pub struct ServerHandle {
-    tx: tokio::sync::mpsc::Sender<ServerSetting>,
+    tx: tokio::sync::mpsc::Sender<ServerCommand>,
 }
 
 /// A server task that has been created but not yet spawned.
 ///
 /// This is returned, alongside its [`ServerHandle`], by the `create_*_server_task` functions.
 /// Drive it to completion by awaiting [`ServerTask::run`], typically from within
-/// [`tokio::spawn`]. The task completes when the associated [`ServerHandle`] is dropped or
+/// [`tokio::spawn`]. The task completes when every associated [`ServerHandle`] is dropped or
 /// [`ServerHandle::shutdown`] is called.
 ///
 /// Unlike the `spawn_*_server_task` functions, no tracing span is attached to the task, so the
@@ -52,14 +52,14 @@ pub struct ServerTask<T: RequestHandler> {
 enum ServerTaskInner<T: RequestHandler> {
     Tcp(
         Box<TcpServerTask<T>>,
-        tokio::sync::mpsc::Receiver<ServerSetting>,
+        tokio::sync::mpsc::Receiver<ServerCommand>,
     ),
     #[cfg(feature = "serial")]
     Rtu(Box<crate::serial::server::RtuServerTask<T>>),
 }
 
 impl<T: RequestHandler> ServerTask<T> {
-    fn tcp(task: TcpServerTask<T>, commands: tokio::sync::mpsc::Receiver<ServerSetting>) -> Self {
+    fn tcp(task: TcpServerTask<T>, commands: tokio::sync::mpsc::Receiver<ServerCommand>) -> Self {
         Self {
             inner: ServerTaskInner::Tcp(Box::new(task), commands),
         }
@@ -72,7 +72,7 @@ impl<T: RequestHandler> ServerTask<T> {
         }
     }
 
-    /// Run the server task until the [`ServerHandle`] is dropped or
+    /// Run the server task until every [`ServerHandle`] is dropped or
     /// [`ServerHandle::shutdown`] is called.
     pub async fn run(self) {
         match self.inner {
@@ -89,19 +89,21 @@ impl ServerHandle {
     /// Construct a [ServerHandle] from its fields
     ///
     /// This function is only required for the C bindings
-    pub fn new(tx: tokio::sync::mpsc::Sender<ServerSetting>) -> Self {
+    pub fn new(tx: tokio::sync::mpsc::Sender<ServerCommand>) -> Self {
         ServerHandle { tx }
     }
 
     /// Change the decoding level for future sessions and all active sessions
     pub async fn set_decode_level(&mut self, level: DecodeLevel) -> Result<(), Shutdown> {
-        self.tx.send(ServerSetting::ChangeDecoding(level)).await?;
+        self.tx.send(ServerCommand::ChangeDecoding(level)).await?;
         Ok(())
     }
 
-    /// Shut down the server task, even if this [`ServerHandle`] is still alive
+    /// Begin shutting down the server task, even if one or more [`ServerHandle`]s are still alive
+    ///
+    /// The task completes when it processes the command, which may be after this returns
     pub async fn shutdown(&self) -> Result<(), Shutdown> {
-        self.tx.send(ServerSetting::Shutdown).await?;
+        self.tx.send(ServerCommand::Shutdown).await?;
         Ok(())
     }
 }
@@ -153,7 +155,7 @@ pub fn create_tcp_server_task<T: RequestHandler>(
     filter: AddressFilter,
     decode: DecodeLevel,
 ) -> (ServerHandle, ServerTask<T>) {
-    let (tx, rx) = tokio::sync::mpsc::channel(SERVER_SETTING_CHANNEL_CAPACITY);
+    let (tx, rx) = tokio::sync::mpsc::channel(SERVER_COMMAND_CHANNEL_CAPACITY);
     let task = TcpServerTask::new(
         max_sessions,
         listener,
@@ -212,7 +214,7 @@ pub fn create_rtu_server_task<T: RequestHandler>(
     handlers: ServerHandlerMap<T>,
     decode: DecodeLevel,
 ) -> (ServerHandle, ServerTask<T>) {
-    let (tx, rx) = tokio::sync::mpsc::channel(SERVER_SETTING_CHANNEL_CAPACITY);
+    let (tx, rx) = tokio::sync::mpsc::channel(SERVER_COMMAND_CHANNEL_CAPACITY);
     let session = crate::server::task::SessionTask::new(
         handlers,
         crate::server::task::AuthorizationType::None,
@@ -410,7 +412,7 @@ fn create_tls_server_task_impl<T: RequestHandler>(
     filter: AddressFilter,
     decode: DecodeLevel,
 ) -> (ServerHandle, ServerTask<T>) {
-    let (tx, rx) = tokio::sync::mpsc::channel(SERVER_SETTING_CHANNEL_CAPACITY);
+    let (tx, rx) = tokio::sync::mpsc::channel(SERVER_COMMAND_CHANNEL_CAPACITY);
     let task = TcpServerTask::new(
         max_sessions,
         listener,

--- a/rodbus/src/server/task.rs
+++ b/rodbus/src/server/task.rs
@@ -18,9 +18,7 @@ use std::sync::Arc;
 #[derive(Copy, Clone)]
 pub enum ServerSetting {
     ChangeDecoding(DecodeLevel),
-    /// Terminate the server task
-    ///
-    /// Queued like any other setting, so anything ahead of it is applied first
+    /// Shut down the server task
     Shutdown,
 }
 
@@ -138,7 +136,7 @@ where
         }
     }
 
-    /// Apply a setting, or report that the task was asked to terminate
+    /// Apply a setting, returning `Err(Shutdown)` if the session should complete
     fn apply_setting(&mut self, setting: ServerSetting) -> Result<(), Shutdown> {
         match setting {
             ServerSetting::ChangeDecoding(level) => {

--- a/rodbus/src/server/task.rs
+++ b/rodbus/src/server/task.rs
@@ -14,9 +14,10 @@ use crate::server::request::{Request, RequestDisplay};
 use scursor::ReadCursor;
 use std::sync::Arc;
 
-/// Messages that can be sent to change server settings dynamically
+/// Commands that can be sent to a running server task
 #[derive(Copy, Clone)]
-pub enum ServerSetting {
+pub enum ServerCommand {
+    /// Change the decoding level dynamically
     ChangeDecoding(DecodeLevel),
     /// Shut down the server task
     Shutdown,
@@ -28,7 +29,7 @@ where
 {
     handlers: ServerHandlerMap<T>,
     auth: AuthorizationType,
-    commands: tokio::sync::mpsc::Receiver<ServerSetting>,
+    commands: tokio::sync::mpsc::Receiver<ServerCommand>,
     writer: FrameWriter,
     reader: FramedReader,
     decode: DecodeLevel,
@@ -43,7 +44,7 @@ where
         auth: AuthorizationType,
         writer: FrameWriter,
         reader: FramedReader,
-        commands: tokio::sync::mpsc::Receiver<ServerSetting>,
+        commands: tokio::sync::mpsc::Receiver<ServerCommand>,
         decode: DecodeLevel,
     ) -> Self {
         Self {
@@ -96,7 +97,7 @@ where
         &mut self,
         duration: std::time::Duration,
     ) -> Result<(), Shutdown> {
-        match tokio::time::timeout(duration, self.process_settings()).await {
+        match tokio::time::timeout(duration, self.process_commands()).await {
             // mpsc closed
             Ok(_) => Err(Shutdown),
             // timeout elapsed
@@ -105,12 +106,12 @@ where
     }
 
     #[cfg(feature = "serial")]
-    async fn process_settings(&mut self) -> Shutdown {
+    async fn process_commands(&mut self) -> Shutdown {
         loop {
             match self.commands.recv().await {
                 None => return Shutdown,
-                Some(setting) => {
-                    if self.apply_setting(setting).is_err() {
+                Some(command) => {
+                    if self.apply_command(command).is_err() {
                         return Shutdown;
                     }
                 }
@@ -127,7 +128,7 @@ where
             cmd = self.commands.recv() => {
                match cmd {
                     None => Err(crate::error::RequestError::Shutdown),
-                    Some(setting) => match self.apply_setting(setting) {
+                    Some(command) => match self.apply_command(command) {
                         Ok(()) => Ok(()),
                         Err(Shutdown) => Err(crate::error::RequestError::Shutdown),
                     },
@@ -136,14 +137,14 @@ where
         }
     }
 
-    /// Apply a setting, returning `Err(Shutdown)` if the session should complete
-    fn apply_setting(&mut self, setting: ServerSetting) -> Result<(), Shutdown> {
-        match setting {
-            ServerSetting::ChangeDecoding(level) => {
+    /// Apply a command, returning `Err(Shutdown)` if the session should complete
+    fn apply_command(&mut self, command: ServerCommand) -> Result<(), Shutdown> {
+        match command {
+            ServerCommand::ChangeDecoding(level) => {
                 self.decode = level;
                 Ok(())
             }
-            ServerSetting::Shutdown => Err(Shutdown),
+            ServerCommand::Shutdown => Err(Shutdown),
         }
     }
 
@@ -302,7 +303,7 @@ mod tests {
 
     #[tokio::test]
     async fn session_ends_when_shutdown_requested_with_the_handle_still_alive() {
-        // the session reads settings straight from the handle on the RTU path
+        // the session reads commands straight from the handle on the RTU path
         let (tx, rx) = tokio::sync::mpsc::channel(8);
         let (mock, _io) = sfio_tokio_mock_io::mock();
         let mut session = SessionTask::new(

--- a/rodbus/src/server/task.rs
+++ b/rodbus/src/server/task.rs
@@ -18,6 +18,10 @@ use std::sync::Arc;
 #[derive(Copy, Clone)]
 pub enum ServerSetting {
     ChangeDecoding(DecodeLevel),
+    /// Terminate the server task
+    ///
+    /// Queued like any other setting, so anything ahead of it is applied first
+    Shutdown,
 }
 
 pub(crate) struct SessionTask<T>
@@ -108,7 +112,9 @@ where
             match self.commands.recv().await {
                 None => return Shutdown,
                 Some(setting) => {
-                    self.apply_setting(setting);
+                    if self.apply_setting(setting).is_err() {
+                        return Shutdown;
+                    }
                 }
             }
         }
@@ -123,20 +129,23 @@ where
             cmd = self.commands.recv() => {
                match cmd {
                     None => Err(crate::error::RequestError::Shutdown),
-                    Some(setting) => {
-                        self.apply_setting(setting);
-                        Ok(())
-                    }
+                    Some(setting) => match self.apply_setting(setting) {
+                        Ok(()) => Ok(()),
+                        Err(Shutdown) => Err(crate::error::RequestError::Shutdown),
+                    },
                }
             }
         }
     }
 
-    fn apply_setting(&mut self, setting: ServerSetting) {
+    /// Apply a setting, or report that the task was asked to terminate
+    fn apply_setting(&mut self, setting: ServerSetting) -> Result<(), Shutdown> {
         match setting {
             ServerSetting::ChangeDecoding(level) => {
                 self.decode = level;
+                Ok(())
             }
+            ServerSetting::Shutdown => Err(Shutdown),
         }
     }
 
@@ -230,6 +239,44 @@ where
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::ServerHandle;
+
+    struct DefaultHandler;
+    impl RequestHandler for DefaultHandler {}
+
+    #[tokio::test]
+    async fn session_ends_when_shutdown_requested_with_the_handle_still_alive() {
+        // the session reads settings straight from the handle on the RTU path
+        let (tx, rx) = tokio::sync::mpsc::channel(8);
+        let (mock, _io) = sfio_tokio_mock_io::mock();
+        let mut session = SessionTask::new(
+            ServerHandlerMap::single(UnitId::new(1), DefaultHandler.wrap()),
+            AuthorizationType::None,
+            FrameWriter::tcp(),
+            FramedReader::tcp(),
+            rx,
+            DecodeLevel::nothing(),
+        );
+        let handle = ServerHandle::new(tx);
+
+        // the mock never yields a frame, so the loop is parked on the command queue
+        let task = tokio::spawn(async move {
+            let mut phys = PhysLayer::new_mock(mock);
+            session.run(&mut phys).await
+        });
+
+        handle.shutdown().await.unwrap();
+
+        assert_eq!(task.await.unwrap(), RequestError::Shutdown);
+
+        // the handle outlived the session it terminated, and now reports that it is gone
+        assert!(handle.shutdown().await.is_err());
     }
 }
 

--- a/rodbus/src/server/task.rs
+++ b/rodbus/src/server/task.rs
@@ -240,44 +240,6 @@ where
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::server::ServerHandle;
-
-    struct DefaultHandler;
-    impl RequestHandler for DefaultHandler {}
-
-    #[tokio::test]
-    async fn session_ends_when_shutdown_requested_with_the_handle_still_alive() {
-        // the session reads settings straight from the handle on the RTU path
-        let (tx, rx) = tokio::sync::mpsc::channel(8);
-        let (mock, _io) = sfio_tokio_mock_io::mock();
-        let mut session = SessionTask::new(
-            ServerHandlerMap::single(UnitId::new(1), DefaultHandler.wrap()),
-            AuthorizationType::None,
-            FrameWriter::tcp(),
-            FramedReader::tcp(),
-            rx,
-            DecodeLevel::nothing(),
-        );
-        let handle = ServerHandle::new(tx);
-
-        // the mock never yields a frame, so the loop is parked on the command queue
-        let task = tokio::spawn(async move {
-            let mut phys = PhysLayer::new_mock(mock);
-            session.run(&mut phys).await
-        });
-
-        handle.shutdown().await.unwrap();
-
-        assert_eq!(task.await.unwrap(), RequestError::Shutdown);
-
-        // the handle outlived the session it terminated, and now reports that it is gone
-        assert!(handle.shutdown().await.is_err());
-    }
-}
-
 /// Determines how authorization of user defined requests are handled
 pub(crate) enum AuthorizationType {
     /// Requests do not require authorization checks (TCP / RTU)
@@ -327,5 +289,43 @@ impl AuthorizationType {
                 result
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::ServerHandle;
+
+    struct DefaultHandler;
+    impl RequestHandler for DefaultHandler {}
+
+    #[tokio::test]
+    async fn session_ends_when_shutdown_requested_with_the_handle_still_alive() {
+        // the session reads settings straight from the handle on the RTU path
+        let (tx, rx) = tokio::sync::mpsc::channel(8);
+        let (mock, _io) = sfio_tokio_mock_io::mock();
+        let mut session = SessionTask::new(
+            ServerHandlerMap::single(UnitId::new(1), DefaultHandler.wrap()),
+            AuthorizationType::None,
+            FrameWriter::tcp(),
+            FramedReader::tcp(),
+            rx,
+            DecodeLevel::nothing(),
+        );
+        let handle = ServerHandle::new(tx);
+
+        // the mock never yields a frame, so the loop is parked on the command queue
+        let task = tokio::spawn(async move {
+            let mut phys = PhysLayer::new_mock(mock);
+            session.run(&mut phys).await
+        });
+
+        handle.shutdown().await.unwrap();
+
+        assert_eq!(task.await.unwrap(), RequestError::Shutdown);
+
+        // the handle outlived the session it terminated, and now reports that it is gone
+        assert_eq!(handle.shutdown().await, Err(Shutdown));
     }
 }

--- a/rodbus/src/tcp/client.rs
+++ b/rodbus/src/tcp/client.rs
@@ -75,6 +75,45 @@ impl TcpTaskConnectionHandler {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::maybe_async::MaybeAsync;
+    use crate::retry::default_retry_strategy;
+    use std::net::Ipv4Addr;
+
+    struct StateRecorder {
+        tx: tokio::sync::mpsc::UnboundedSender<ClientState>,
+    }
+
+    impl Listener<ClientState> for StateRecorder {
+        fn update(&mut self, value: ClientState) -> MaybeAsync<()> {
+            let _ = self.tx.send(value);
+            MaybeAsync::ready(())
+        }
+    }
+
+    #[tokio::test]
+    async fn reports_shutdown_state_when_shutdown_requested() {
+        let (tx, mut states) = tokio::sync::mpsc::unbounded_channel();
+        // the channel is never enabled, so the host is never dialed
+        let (channel, task) = create_tcp_channel(
+            HostAddr::ip(Ipv4Addr::LOCALHOST.into(), 502),
+            default_retry_strategy(),
+            Box::new(StateRecorder { tx }),
+            ClientOptions::default(),
+        );
+        let task = tokio::spawn(task.run());
+
+        channel.shutdown().await.unwrap();
+        task.await.unwrap();
+
+        // the task announced its own termination on the way out
+        assert_eq!(states.recv().await, Some(ClientState::Disabled));
+        assert_eq!(states.recv().await, Some(ClientState::Shutdown));
+    }
+}
+
 pub(crate) struct TcpChannelTask {
     host: HostAddr,
     connect_retry: Box<dyn RetryStrategy>,

--- a/rodbus/src/tcp/client.rs
+++ b/rodbus/src/tcp/client.rs
@@ -75,45 +75,6 @@ impl TcpTaskConnectionHandler {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::maybe_async::MaybeAsync;
-    use crate::retry::default_retry_strategy;
-    use std::net::Ipv4Addr;
-
-    struct StateRecorder {
-        tx: tokio::sync::mpsc::UnboundedSender<ClientState>,
-    }
-
-    impl Listener<ClientState> for StateRecorder {
-        fn update(&mut self, value: ClientState) -> MaybeAsync<()> {
-            let _ = self.tx.send(value);
-            MaybeAsync::ready(())
-        }
-    }
-
-    #[tokio::test]
-    async fn reports_shutdown_state_when_shutdown_requested() {
-        let (tx, mut states) = tokio::sync::mpsc::unbounded_channel();
-        // the channel is never enabled, so the host is never dialed
-        let (channel, task) = create_tcp_channel(
-            HostAddr::ip(Ipv4Addr::LOCALHOST.into(), 502),
-            default_retry_strategy(),
-            Box::new(StateRecorder { tx }),
-            ClientOptions::default(),
-        );
-        let task = tokio::spawn(task.run());
-
-        channel.shutdown().await.unwrap();
-        task.await.unwrap();
-
-        // the task announced its own termination on the way out
-        assert_eq!(states.recv().await, Some(ClientState::Disabled));
-        assert_eq!(states.recv().await, Some(ClientState::Shutdown));
-    }
-}
-
 pub(crate) struct TcpChannelTask {
     host: HostAddr,
     connect_retry: Box<dyn RetryStrategy>,
@@ -242,5 +203,44 @@ impl TcpChannelTask {
             .get()
             .await;
         self.client_loop.fail_requests_for(delay).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::maybe_async::MaybeAsync;
+    use crate::retry::default_retry_strategy;
+    use std::net::Ipv4Addr;
+
+    struct StateRecorder {
+        tx: tokio::sync::mpsc::UnboundedSender<ClientState>,
+    }
+
+    impl Listener<ClientState> for StateRecorder {
+        fn update(&mut self, value: ClientState) -> MaybeAsync<()> {
+            let _ = self.tx.send(value);
+            MaybeAsync::ready(())
+        }
+    }
+
+    #[tokio::test]
+    async fn reports_shutdown_state_when_shutdown_requested() {
+        let (tx, mut states) = tokio::sync::mpsc::unbounded_channel();
+        // the channel is never enabled, so the host is never dialed
+        let (channel, task) = create_tcp_channel(
+            HostAddr::ip(Ipv4Addr::LOCALHOST.into(), 502),
+            default_retry_strategy(),
+            Box::new(StateRecorder { tx }),
+            ClientOptions::default(),
+        );
+        let task = tokio::spawn(task.run());
+
+        channel.shutdown().await.unwrap();
+        task.await.unwrap();
+
+        // the task announced its own termination on the way out
+        assert_eq!(states.recv().await, Some(ClientState::Disabled));
+        assert_eq!(states.recv().await, Some(ClientState::Shutdown));
     }
 }

--- a/rodbus/src/tcp/server.rs
+++ b/rodbus/src/tcp/server.rs
@@ -6,7 +6,7 @@ use crate::common::frame::{FrameWriter, FramedReader};
 use crate::common::phys::PhysLayer;
 use crate::decode::DecodeLevel;
 use crate::server::handler::{RequestHandler, ServerHandlerMap};
-use crate::server::task::{AuthorizationType, ServerSetting};
+use crate::server::task::{AuthorizationType, ServerCommand};
 
 use crate::server::AddressFilter;
 use std::net::SocketAddr;
@@ -21,7 +21,7 @@ struct SessionClose(u128);
 struct SessionTracker {
     max_sessions: usize,
     id: u128,
-    sessions: BTreeMap<u128, tokio::sync::mpsc::Sender<ServerSetting>>,
+    sessions: BTreeMap<u128, tokio::sync::mpsc::Sender<ServerCommand>>,
 }
 
 impl SessionTracker {
@@ -45,7 +45,7 @@ impl SessionTracker {
         ret
     }
 
-    pub(crate) fn add(&mut self, sender: tokio::sync::mpsc::Sender<ServerSetting>) -> u128 {
+    pub(crate) fn add(&mut self, sender: tokio::sync::mpsc::Sender<ServerCommand>) -> u128 {
         if self.sessions.len() >= self.max_sessions {
             if let Some(oldest) = self.sessions.keys().next().copied() {
                 tracing::warn!(
@@ -134,35 +134,35 @@ where
         }
     }
 
-    async fn change_setting(&mut self, setting: ServerSetting) {
+    async fn apply_command(&mut self, command: ServerCommand) {
         // first, change it locally so that it is applied to new sessions
-        match setting {
-            ServerSetting::ChangeDecoding(level) => {
+        match command {
+            ServerCommand::ChangeDecoding(level) => {
                 tracing::info!("changed decoding level to {:?}", level);
                 self.decode = level;
             }
             // handled by the caller, which returns instead of forwarding it to the sessions
-            ServerSetting::Shutdown => return,
+            ServerCommand::Shutdown => return,
         }
 
         for sender in self.tracker.sessions.values_mut() {
-            // best effort to send the setting to each session this isn't critical so we wouldn't
+            // best effort to send the command to each session this isn't critical so we wouldn't
             // want to slow the server down by awaiting it
-            let _ = sender.send(setting).await;
+            let _ = sender.send(command).await;
         }
     }
 
-    pub(crate) async fn run(&mut self, mut commands: tokio::sync::mpsc::Receiver<ServerSetting>) {
+    pub(crate) async fn run(&mut self, mut commands: tokio::sync::mpsc::Receiver<ServerCommand>) {
         loop {
             tokio::select! {
-               setting = commands.recv() => {
-                    match setting {
+               command = commands.recv() => {
+                    match command {
                         // dropping the tracker ends every session, just as dropping the handle does
-                        Some(ServerSetting::Shutdown) => {
+                        Some(ServerCommand::Shutdown) => {
                             tracing::info!("server shutdown requested");
                             return;
                         }
-                        Some(setting) => self.change_setting(setting).await,
+                        Some(command) => self.apply_command(command).await,
                         None => {
                             tracing::info!("server shutdown");
                             return; // shutdown signal
@@ -243,7 +243,7 @@ async fn run_session<T: RequestHandler>(
     mut handler: TcpServerConnectionHandler,
     decode: DecodeLevel,
     handlers: ServerHandlerMap<T>,
-    commands: tokio::sync::mpsc::Receiver<ServerSetting>,
+    commands: tokio::sync::mpsc::Receiver<ServerCommand>,
 ) {
     match handler.handle(socket).await {
         Err(err) => {

--- a/rodbus/src/tcp/server.rs
+++ b/rodbus/src/tcp/server.rs
@@ -141,6 +141,8 @@ where
                 tracing::info!("changed decoding level to {:?}", level);
                 self.decode = level;
             }
+            // handled by the caller, which returns instead of forwarding it to the sessions
+            ServerSetting::Shutdown => return,
         }
 
         for sender in self.tracker.sessions.values_mut() {
@@ -155,6 +157,11 @@ where
             tokio::select! {
                setting = commands.recv() => {
                     match setting {
+                        // dropping the tracker ends every session, just as dropping the handle does
+                        Some(ServerSetting::Shutdown) => {
+                            tracing::info!("server shutdown requested");
+                            return;
+                        }
                         Some(setting) => self.change_setting(setting).await,
                         None => {
                             tracing::info!("server shutdown");
@@ -227,6 +234,36 @@ where
 
         // spawn the session off onto another task
         tokio::spawn(session);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::create_tcp_server_task;
+    use crate::UnitId;
+
+    struct DefaultHandler;
+    impl RequestHandler for DefaultHandler {}
+
+    #[tokio::test]
+    async fn task_ends_when_shutdown_requested_with_the_handle_still_alive() {
+        // bound but never connected to: shutdown is a queued command, not something on the wire
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let (handle, task) = create_tcp_server_task(
+            1,
+            listener,
+            ServerHandlerMap::single(UnitId::new(1), DefaultHandler.wrap()),
+            AddressFilter::Any,
+            DecodeLevel::nothing(),
+        );
+        let task = tokio::spawn(task.run());
+
+        handle.shutdown().await.unwrap();
+        task.await.unwrap();
+
+        // the handle outlived the task it terminated, and now reports that it is gone
+        assert!(handle.shutdown().await.is_err());
     }
 }
 

--- a/rodbus/src/tcp/server.rs
+++ b/rodbus/src/tcp/server.rs
@@ -237,36 +237,6 @@ where
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::server::create_tcp_server_task;
-    use crate::UnitId;
-
-    struct DefaultHandler;
-    impl RequestHandler for DefaultHandler {}
-
-    #[tokio::test]
-    async fn task_ends_when_shutdown_requested_with_the_handle_still_alive() {
-        // bound but never connected to: shutdown is a queued command, not something on the wire
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let (handle, task) = create_tcp_server_task(
-            1,
-            listener,
-            ServerHandlerMap::single(UnitId::new(1), DefaultHandler.wrap()),
-            AddressFilter::Any,
-            DecodeLevel::nothing(),
-        );
-        let task = tokio::spawn(task.run());
-
-        handle.shutdown().await.unwrap();
-        task.await.unwrap();
-
-        // the handle outlived the task it terminated, and now reports that it is gone
-        assert!(handle.shutdown().await.is_err());
-    }
-}
-
 async fn run_session<T: RequestHandler>(
     socket: tokio::net::TcpStream,
     addr: SocketAddr,
@@ -291,5 +261,36 @@ async fn run_session<T: RequestHandler>(
             .run(&mut phys)
             .await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Shutdown;
+    use crate::server::create_tcp_server_task;
+    use crate::UnitId;
+
+    struct DefaultHandler;
+    impl RequestHandler for DefaultHandler {}
+
+    #[tokio::test]
+    async fn task_ends_when_shutdown_requested_with_the_handle_still_alive() {
+        // bound but never connected to: shutdown is a queued command, not something on the wire
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let (handle, task) = create_tcp_server_task(
+            1,
+            listener,
+            ServerHandlerMap::single(UnitId::new(1), DefaultHandler.wrap()),
+            AddressFilter::Any,
+            DecodeLevel::nothing(),
+        );
+        let task = tokio::spawn(task.run());
+
+        handle.shutdown().await.unwrap();
+        task.await.unwrap();
+
+        // the handle outlived the task it terminated, and now reports that it is gone
+        assert_eq!(handle.shutdown().await, Err(Shutdown));
     }
 }


### PR DESCRIPTION
## Problem

The client task completes only when every `Channel` clone has been dropped:
`Receiver::recv()` returns `None` once the last sender goes away, which becomes
`SessionError::Shutdown`.

That makes termination depend on how many handles exist and where they are held.
A caller that publishes a `Channel` somewhere outliving the task — a service
registry, a shared cache, anything with process lifetime — can never terminate
it, and awaiting the task's `JoinHandle` hangs.

Dropping handles in the right order is a convention every holder has to honour,
and nothing in the type system enforces it.

## Change

Adds `Channel::shutdown()`, which sends shutdown as a command rather than
signalling it by releasing the last handle:

```rust
pub async fn shutdown(&self) -> Result<(), Shutdown>
```

Drop-based termination is unchanged, so this is additive — existing callers need
no changes.

Command gains a Shutdown variant, handled at both points where
reads its queue:

- run_cmd, while connected, returning SessionError::Shutdown
- fail_next_request, while disconnected or waiting to retry, r
StateChange::Shutdown

Both already existed for the drop case, so this reuses the wind-down path rather
than adding a second one. Handling only the first would leave
solely while the device is reachable.

## Semantics

- Queued behind pending requests, so anything already in the queue is still
processed — matching what dropping every handle does, since an
buffer before reporting closure.
- A transaction already in flight runs to completion, so the t
within one response timeout of the last queued request.
- Requests made after shutdown fail with RequestError::Shutdow
- Signals the task rather than waiting on it; await ClientTask::run to observe
completion.
- Returns Err(Shutdown) if the task has already terminated, so a second call is
harmless.

TCP and serial share ClientLoop, so both are covered with no
channel task.